### PR TITLE
Added AllBucketsZeroException, added extra checks for bucket validity

### DIFF
--- a/include/sketch.h
+++ b/include/sketch.h
@@ -40,6 +40,13 @@ public:
   friend Sketch operator* (const Sketch &sketch1, long scaling_factor );
 };
 
+class AllBucketsZeroException : public exception {
+public:
+  virtual const char* what() const throw() {
+    return "All buckets zero";
+  }
+};
+
 class MultipleQueryException : public exception {
   virtual const char* what() const throw() {
     return "This sketch has already been sampled!";

--- a/l0_sampling/sketch.cpp
+++ b/l0_sampling/sketch.cpp
@@ -36,15 +36,24 @@ Update Sketch::query(){
     throw MultipleQueryException();
   }
   already_quered = true;
+  bool all_buckets_zero = true;
   for (int i = 0; i < buckets.size(); i++){
     Bucket& b = buckets[i];
-    if ( b.a != 0 && b.b % b.a == 0 && (b.c - b.a*PrimeGenerator::power(b.r,b.b/b.a,random_prime))% random_prime == 0  ){
+    if (b.a != 0 || b.b != 0 || b.c != 0) {
+      all_buckets_zero = false;
+    }
+    if (b.a != 0 && b.b % b.a == 0 && (b.c - b.a*PrimeGenerator::power(b.r,b.b/b.a,random_prime))% random_prime == 0
+      && 0 < b.b/b.a && b.b/b.a <= n && b.contains(b.b/b.a)) {
       //cout << "Passed all tests: " << "b.a: " << b.a << " b.b: " << b.b << " b.c: " << b.c << " Guess: " << b.guess_nonzero << " r: " << b.r << endl;
       //cout << "String: " << b.stuff << endl;
       return {b.b/b.a - 1,b.a}; // 0-index adjustment
     }
   }
-  throw NoGoodBucketException();
+  if (all_buckets_zero) {
+    throw AllBucketsZeroException();
+  } else {
+    throw NoGoodBucketException();
+  }
 }
 
 Sketch operator+ (const Sketch &sketch1, const Sketch &sketch2){

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -5,7 +5,7 @@
 
 TEST(SketchTestSuite, TestExceptions) {
   Sketch sketch = Sketch(10,rand());
-  ASSERT_THROW(sketch.query(), NoGoodBucketException);
+  ASSERT_THROW(sketch.query(), AllBucketsZeroException);
   ASSERT_THROW(sketch.query(), MultipleQueryException);
 }
 

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -4,9 +4,45 @@
 #include "../include/update.h"
 
 TEST(SketchTestSuite, TestExceptions) {
-  Sketch sketch = Sketch(10,rand());
-  ASSERT_THROW(sketch.query(), AllBucketsZeroException);
-  ASSERT_THROW(sketch.query(), MultipleQueryException);
+  Sketch sketch1 = Sketch(10,rand());
+  ASSERT_THROW(sketch1.query(), AllBucketsZeroException);
+  ASSERT_THROW(sketch1.query(), MultipleQueryException);
+
+  /*
+   * Use deterministic sketch
+   * This generates the following buckets:
+   * 1111111111
+   * 1001010011
+   * 0100000100
+   * 0000000000
+   * 1111111111
+   * 0010100111
+   * 0111100000
+   * 0000110101
+   * 1111111111
+   * 0101011010
+   * 0000000010
+   * 0000000000
+   * 1111111111
+   * 0000000010
+   * 0000011000
+   * 0000000000
+   * 0100000000
+   *
+   * To find a set of indicies where no good buckets exist, repeatedly
+   * eliminate the index of a good bucket until no good buckets exist.
+   *
+   * Once we have our indicies, try deltas until all buckets are not good.
+   */
+  Sketch sketch2 = Sketch(10, 1);
+  sketch2.update({0, 1});
+  sketch2.update({2, 1});
+  sketch2.update({3, 1});
+  sketch2.update({4, 1});
+  sketch2.update({5, 1});
+  sketch2.update({6, 1});
+  sketch2.update({9, 1});
+  ASSERT_THROW(sketch2.query(), NoGoodBucketException);
 }
 
 TEST(SketchTestSuite, GIVENonlyIndexZeroUpdatedTHENitWorks) {


### PR DESCRIPTION
When all bucket's a b c values are zero, instead of throwing NoGoodBucketException, throw AllBucketsZeroException.

Also, added extra checks for if a bucket is good: make sure the returned index in in bounds and in the bucket.