### PR TITLE
bug fix for prime generation.

### DIFF
--- a/include/prime_generator.h
+++ b/include/prime_generator.h
@@ -34,7 +34,7 @@ namespace PrimeGenerator{
     if (n % 2 == 0){
       n++;
     }
-    while(IsPrime(n)){
+    while(!IsPrime(n)){
       n += 2;
     }
     return n;

--- a/include/prime_generator_native.h
+++ b/include/prime_generator_native.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <cmath>
+
 typedef long long int ll;
 typedef unsigned long long int ull;
 

--- a/include/prime_generator_native.h
+++ b/include/prime_generator_native.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <cmath>
 typedef long long int ll;
 typedef unsigned long long int ull;
 
@@ -35,7 +35,7 @@ namespace PrimeGeneratorNative {
     if (n % 2 == 0){
       n++;
     }
-    while(IsPrime(n)){
+    while(!IsPrime(n)){
       n += 2;
     }
     return n;


### PR DESCRIPTION
I think I found a bug where prime generation is returning a composite number rather than a prime number. Not sure exactly what the implications are of this issue but I'm sure it's not great.

Let me know if I'm missing something but I think the following is the solution.

prime_generator.h -> change line 37 to while(!isPrime())
prime_generator_native.h -> change line 38 to while(!isPrime())

I built a quick testing script and got the following results:
prime generated from 5 is 9
prime generated from 10 is 15
prime generated from 23 is 25

This pull request should fix this issue