### PR TITLE
Fixed memory leaks

### DIFF
--- a/graph.cpp
+++ b/graph.cpp
@@ -20,7 +20,8 @@ Graph::Graph(uint64_t num_nodes): num_nodes(num_nodes) {
 Graph::~Graph() {
   for (unsigned i=0;i<num_nodes;++i)
     delete supernodes[i];
-  delete supernodes;
+  delete[] supernodes;
+  delete[] parent;
   delete representatives;
 }
 

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -23,6 +23,7 @@ public:
    * @param seed  the (fixed) seed value passed to each supernode.
    */
   Supernode(uint64_t n, long seed);
+  ~Supernode();
 
   /**
    * Function to sample an edge from the cut of a supernode.

--- a/supernode.cpp
+++ b/supernode.cpp
@@ -13,6 +13,11 @@ Supernode::Supernode(uint64_t n, long seed): sketches(log2(n)), idx(0), logn(log
     sketches[i] = new Sketch(n*n, r);
 }
 
+Supernode::~Supernode() {
+  for (int i=0;i<logn;++i)
+    delete sketches[i];
+}
+
 boost::optional<Edge> Supernode::sample() {
   if (idx == logn) throw OutOfQueriesException();
   vec_t query_idx;


### PR DESCRIPTION
I think eventually we should probably use std::vectors for this instead of manually managing the memory ourselves. We're using cpp so may as well take advantage of the standard library.

I don't know if that would mess up the SWIG stuff or not, so I just fixed the memory leaks for now.