### PR TITLE
K connectivity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ include_directories("${Boost_INCLUDE_DIR}")
 #  target_compile_options(l0sampling PRIVATE /O2)
 #endif()
 
-set(ENV{DEBUG} TRUE)
+#set(ENV{DEBUG} TRUE)
 
 add_executable(tests
   test/test_runner.cpp
@@ -221,31 +221,31 @@ endif ()
 #    target_compile_options(min_cut_test PRIVATE /O2)
 #  endif()
 #endif ()
-#
-#add_executable(native_tests
-#  test/test_runner.cpp
-#  test/graph_test.cpp
-#  test/sketch_test.cpp
-#  test/supernode_test.cpp
-#  test/util_test.cpp
-#  test/util/graph_verifier.cpp
-#  test/util/graph_gen.cpp
-#  test/util/graph_gen_test.cpp
-#  test/util/graph_verifier_test.cpp
-#  graph.cpp
-#  supernode.cpp
-#  l0_sampling/sketch.cpp
-#  util.cpp)
-#target_link_libraries(native_tests PRIVATE xxHash::xxhash GTest::gtest)
-#target_compile_definitions(native_tests PRIVATE VERIFY_SAMPLES_F USE_NATIVE_F)
-## optimize unless debug
-#if (DEFINED ENV{DEBUG})
-#  message("Disabling optimizations and enabling debug symbols")
-#  target_compile_options(native_tests PRIVATE -g)
-#else ()
-#  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-#    target_compile_options(native_tests PRIVATE -O3)
-#  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-#    target_compile_options(native_tests PRIVATE /O2)
-#  endif()
-#endif ()
+
+add_executable(native_tests
+  test/test_runner.cpp
+  test/graph_test.cpp
+  test/sketch_test.cpp
+  test/supernode_test.cpp
+  test/util_test.cpp
+  test/util/graph_verifier.cpp
+  test/util/graph_gen.cpp
+  test/util/graph_gen_test.cpp
+  test/util/graph_verifier_test.cpp
+  graph.cpp
+  supernode.cpp
+  l0_sampling/sketch.cpp
+  util.cpp)
+target_link_libraries(native_tests PRIVATE xxHash::xxhash GTest::gtest)
+target_compile_definitions(native_tests PRIVATE VERIFY_SAMPLES_F USE_NATIVE_F)
+# optimize unless debug
+if (DEFINED ENV{DEBUG})
+  message("Disabling optimizations and enabling debug symbols")
+  target_compile_options(native_tests PRIVATE -g)
+else ()
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(native_tests PRIVATE -O3)
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    target_compile_options(native_tests PRIVATE /O2)
+  endif()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,28 +200,28 @@ else ()
   endif()
 endif ()
 
-add_executable(min_cut_test
-  goof_lab/min_cut_test.cpp
-  test/util/graph_verifier.cpp
-  test/util/graph_gen.cpp
-  graph.cpp
-  supernode.cpp
-  l0_sampling/sketch.cpp
-  util.cpp)
-target_link_libraries(min_cut_test PRIVATE xxHash::xxhash GTest::gtest)
-target_compile_definitions(min_cut_test PRIVATE VERIFY_SAMPLES_F)
-# optimize unless debug
-if (DEFINED ENV{DEBUG})
-  message("Disabling optimizations and enabling debug symbols")
-  target_compile_options(min_cut_test PRIVATE -g)
-else ()
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(min_cut_test PRIVATE -O3)
-  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    target_compile_options(min_cut_test PRIVATE /O2)
-  endif()
-endif ()
-
+#add_executable(min_cut_test
+#  goof_lab/min_cut_test.cpp
+#  test/util/graph_verifier.cpp
+#  test/util/graph_gen.cpp
+#  graph.cpp
+#  supernode.cpp
+#  l0_sampling/sketch.cpp
+#  util.cpp)
+#target_link_libraries(min_cut_test PRIVATE xxHash::xxhash GTest::gtest)
+#target_compile_definitions(min_cut_test PRIVATE VERIFY_SAMPLES_F)
+## optimize unless debug
+#if (DEFINED ENV{DEBUG})
+#  message("Disabling optimizations and enabling debug symbols")
+#  target_compile_options(min_cut_test PRIVATE -g)
+#else ()
+#  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#    target_compile_options(min_cut_test PRIVATE -O3)
+#  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+#    target_compile_options(min_cut_test PRIVATE /O2)
+#  endif()
+#endif ()
+#
 #add_executable(native_tests
 #  test/test_runner.cpp
 #  test/graph_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,8 @@ include_directories("${Boost_INCLUDE_DIR}")
 #  target_compile_options(l0sampling PRIVATE /O2)
 #endif()
 
+set(ENV{DEBUG} TRUE)
+
 add_executable(tests
   test/test_runner.cpp
   test/graph_test.cpp
@@ -198,30 +200,52 @@ else ()
   endif()
 endif ()
 
-add_executable(native_tests
-  test/test_runner.cpp
-  test/graph_test.cpp
-  test/sketch_test.cpp
-  test/supernode_test.cpp
-  test/util_test.cpp
+add_executable(min_cut_test
+  goof_lab/min_cut_test.cpp
   test/util/graph_verifier.cpp
   test/util/graph_gen.cpp
-  test/util/graph_gen_test.cpp
-  test/util/graph_verifier_test.cpp
   graph.cpp
   supernode.cpp
   l0_sampling/sketch.cpp
   util.cpp)
-target_link_libraries(native_tests PRIVATE xxHash::xxhash GTest::gtest)
-target_compile_definitions(native_tests PRIVATE VERIFY_SAMPLES_F USE_NATIVE_F)
+target_link_libraries(min_cut_test PRIVATE xxHash::xxhash GTest::gtest)
+target_compile_definitions(min_cut_test PRIVATE VERIFY_SAMPLES_F)
 # optimize unless debug
 if (DEFINED ENV{DEBUG})
   message("Disabling optimizations and enabling debug symbols")
-  target_compile_options(native_tests PRIVATE -g)
+  target_compile_options(min_cut_test PRIVATE -g)
 else ()
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    target_compile_options(native_tests PRIVATE -O3)
+    target_compile_options(min_cut_test PRIVATE -O3)
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    target_compile_options(native_tests PRIVATE /O2)
+    target_compile_options(min_cut_test PRIVATE /O2)
   endif()
 endif ()
+
+#add_executable(native_tests
+#  test/test_runner.cpp
+#  test/graph_test.cpp
+#  test/sketch_test.cpp
+#  test/supernode_test.cpp
+#  test/util_test.cpp
+#  test/util/graph_verifier.cpp
+#  test/util/graph_gen.cpp
+#  test/util/graph_gen_test.cpp
+#  test/util/graph_verifier_test.cpp
+#  graph.cpp
+#  supernode.cpp
+#  l0_sampling/sketch.cpp
+#  util.cpp)
+#target_link_libraries(native_tests PRIVATE xxHash::xxhash GTest::gtest)
+#target_compile_definitions(native_tests PRIVATE VERIFY_SAMPLES_F USE_NATIVE_F)
+## optimize unless debug
+#if (DEFINED ENV{DEBUG})
+#  message("Disabling optimizations and enabling debug symbols")
+#  target_compile_options(native_tests PRIVATE -g)
+#else ()
+#  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#    target_compile_options(native_tests PRIVATE -O3)
+#  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+#    target_compile_options(native_tests PRIVATE /O2)
+#  endif()
+#endif ()

--- a/graph.cpp
+++ b/graph.cpp
@@ -106,7 +106,7 @@ vector<set<Node>> Graph::connected_components() {
 vector<std::pair<set<Node>, set<Edge>>> spanning_forest()
 {
   update_locked = true; // disallow updating the graph after we run the alg
-  // Each node may be the per point of mor than two connected
+  // Each node may be the per point of more than two connected
   // components, so a single dimensional structure is insufficient.
   map<Node, list<Edge>> span_edges(num_nodes);
 

--- a/graph.cpp
+++ b/graph.cpp
@@ -27,10 +27,18 @@ Graph::~Graph() {
   delete representatives;
 }
 
-Graph::Graph(const G& g)
-	:num_nodes = g.num_nodes
-	 representatives{new map<Node, size_t>()}
-	 supernodes{new Supernode*[num_nodes]}
+Graph::Graph(const Graph& g)
+	:num_nodes{g.num_nodes},
+	 representatives{new map<Node, size_t>(g.representatives)},
+	 supernodes{new Supernode* [g.num_nodes]},
+	 parent{new Node[g.num_nodes]}
+{
+  for (Node i = 0; i < num_nodes; i++)
+  {
+    supernodes[i] = new Supernode(g.supernodes[i]);
+    parent[i] = g.parent[i];
+  } 
+}
 
 void Graph::update(GraphUpdate upd) {
   if (update_locked) throw UpdateLockedException();

--- a/graph.cpp
+++ b/graph.cpp
@@ -11,7 +11,7 @@ Graph::Graph(uint64_t num_nodes): num_nodes(num_nodes) {
   representatives = new map<Node, size_t>(); 
   supernodes = new Supernode*[num_nodes];
   parent = new Node[num_nodes];
-  time_t seed = 0; //time(nullptr); TODO 
+  time_t seed = time(nullptr); 
   for (Node i=0;i<num_nodes;++i) {
     (*representatives)[i] = 1;
     supernodes[i] = new Supernode(num_nodes,seed);
@@ -216,8 +216,7 @@ vector<vector<Node>> Graph::k_edge_disjoint_span_forests_union (int k)
         if (node_list_pair.first < neighbor) 
           g_i.update({{node_list_pair.first, neighbor}, DELETE});
   
-  vector<vector<Node>> forest_union;
-  forest_union.reserve(num_nodes);
+  vector<vector<Node>> forest_union(num_nodes);
 
   // Insert current forest edges into union
   for (int i = F_0.size() - 1; i >= 0; i--)
@@ -230,10 +229,10 @@ vector<vector<Node>> Graph::k_edge_disjoint_span_forests_union (int k)
   }
 
   // Repeat above for other instances
-  for (int i = k - 2; i => 0; i--)
+  for (int i = k - 2; i >= 0; i--)
   {
     auto F_i = instances[i].spanning_forest();
-    instances.erase(instances.end());
+    instances.pop_back();
    
     // Remove current forest edges from remaining instances 
     for (int j = i - 1; j >= 0; j--)

--- a/graph.cpp
+++ b/graph.cpp
@@ -194,31 +194,34 @@ vector<unordered_map<Node, vector<Node>>> Graph::spanning_forest()
 
 bool Graph::is_k_edge_connected (int k)
 {
-	// TODO: Should we leave the original instance of the sketch
-	// unaltered? It consumes (k+1)/k times more
-	// memory, but it leaves the original sketch unaltered in
-	// case the user wishes to conduct another algorithm.
-//	vector<Graph> instances(k-1, *this);
-//	auto F_0 = this->spanning_forest();
-//	if (F_0.size() > 1) return false;
-//	for(Graph& g_i : instances)
-//		for (const Edge& e : F_0[0].second)
-//			g_i.update({e, DELETE});
-//
-//	for (int i = 1; i < k - 1; i++)
-//	{
-//		auto F_i = instances[i-1].spanning_forest();
-//
-//		if (F_i.size() > 1) return false;
-//
-//		for (int j = i; j < k; j++)
-//			for (const Edge& e : F_i[0].second)
-//				instances[j].update({e, DELETE});
-//	}
-//
-//	return instances[k].spanning_forest().size() < 2;
-
-	return false;
+  // TODO: Should we leave the original instance of the sketch
+  // unaltered? It consumes (k+1)/k times more
+  // memory, but it leaves the original sketch unaltered in
+  // case the user wishes to conduct another algorithm.
+  vector<Graph> instances(k-1, *this);
+  auto F_0 = this->spanning_forest();
+  if (F_0.size() > 1) return false;
+  for(Graph& g_i : instances)
+    for (const auto& node_list_pair : F_0[0])
+      for (const Node& neighbor : node_list_pair.second)
+        if (node_list_pair.first < neighbor) 
+          g_i.update({{node_list_pair.first, neighbor}, DELETE});
+  
+  for (int i = 0; i < k - 1; i++)
+  {
+    auto F_i = instances[i].spanning_forest();
+  
+    if (F_i.size() > 1) return false;
+  
+    for (int j = i + 1; j <= k - 1; j++)
+      for (const auto& node_list_pair : F_i[0])
+        for (const Node& neighbor : node_list_pair.second)
+          if (node_list_pair.first < neighbor) 
+            instances[j].update(
+                {{node_list_pair.first, neighbor}, DELETE});
+  }
+  
+  return instances[k - 1].spanning_forest().size() < 2;
 }
 
 Node Graph::get_parent(Node node) {

--- a/graph.cpp
+++ b/graph.cpp
@@ -27,6 +27,11 @@ Graph::~Graph() {
   delete representatives;
 }
 
+Graph::Graph(const G& g)
+	:num_nodes = g.num_nodes
+	 representatives{new map<Node, size_t>()}
+	 supernodes{new Supernode*[num_nodes]}
+
 void Graph::update(GraphUpdate upd) {
   if (update_locked) throw UpdateLockedException();
   Edge &edge = upd.first;

--- a/graph.cpp
+++ b/graph.cpp
@@ -163,16 +163,24 @@ vector<std::pair<set<Node>, set<Edge>>> spanning_forest()
 
 bool is_k_edge_connected (int k)
 {
-	vector<Graph> instances(k, *this);
+	// TODO: Should we leave the original instance of the sketch
+	// unaltered? It consumes (k+1)/k times more
+	// memory, but it leaves the original sketch unaltered in
+	// case the user wishes to conduct another algorithm.
+	vector<Graph> instances(k-1, *this);
+	F_0 = this.spanning_forest();
+	if (F_0.size() > 1) return false;
+	for(Graph& g_i : instances)
+		for (const Edge& e : F_0[0].second)
+			g_i.update({e, DELETE});
 
-	for (int i = 1; i < k; i++)
+	for (int i = 1; i < k - 1; i++)
 	{
-		F_i = instances[i].spanning_forest();
+		F_i = instances[i-1].spanning_forest();
 
-		if (F_i.size() > 1)
-			return false;
+		if (F_i.size() > 1) return false;
 
-		for (int j = i + 1; j <= k; j++)
+		for (int j = i; j < k; j++)
 			for (const Edge& e : F_i[0].second)
 				instances[j].update({e, DELETE});
 	}

--- a/graph.cpp
+++ b/graph.cpp
@@ -172,6 +172,9 @@ vector<unordered_map<Node, vector<Node>>> Graph::spanning_forest()
   // Insert edges from merge_points
   for (uint64_t i = 0; i < num_nodes; i++)
   {
+    if (root_adj_list.at(get_parent(i)).count(i) == 0)
+      root_adj_list[get_parent(i)][i] = vector<Node>();
+
     for (const Node& span_neighbor : merge_points[i])
     {
       root_adj_list[get_parent(i)][i].push_back(span_neighbor);

--- a/graph.cpp
+++ b/graph.cpp
@@ -205,7 +205,7 @@ vector<unordered_map<Node, vector<Node>>> Graph::spanning_forest()
   return retval;
 }
 
-bool Graph::k_edge_disjoint_span_forests_union (int k)
+vector<vector<Node>> Graph::k_edge_disjoint_span_forests_union (int k)
 {
   vector<Graph> instances(k-1, *this);
   auto F_0 = this->spanning_forest();
@@ -216,7 +216,7 @@ bool Graph::k_edge_disjoint_span_forests_union (int k)
         if (node_list_pair.first < neighbor) 
           g_i.update({{node_list_pair.first, neighbor}, DELETE});
   
-  vector<Node, vector<Node>> forest_union;
+  vector<vector<Node>> forest_union;
   forest_union.reserve(num_nodes);
 
   // Insert current forest edges into union

--- a/graph.cpp
+++ b/graph.cpp
@@ -29,13 +29,13 @@ Graph::~Graph() {
 
 Graph::Graph(const Graph& g)
 	:num_nodes{g.num_nodes},
-	 representatives{new map<Node, size_t>(g.representatives)},
+	 representatives{new map<Node, size_t>(*(g.representatives))},
 	 supernodes{new Supernode* [g.num_nodes]},
 	 parent{new Node[g.num_nodes]}
 {
   for (Node i = 0; i < num_nodes; i++)
   {
-    supernodes[i] = new Supernode(g.supernodes[i]);
+    supernodes[i] = new Supernode(*(g.supernodes[i]));
     parent[i] = g.parent[i];
   } 
 }

--- a/include/graph.h
+++ b/include/graph.h
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <exception>
 #include <set>
+#include <unordered_map>
 #include <list>
 #include <fstream>
 #include "supernode.h"
@@ -56,11 +57,11 @@ public:
    * forest, where a spanning forest of G is defined as a maximal
    * acyclic subgraph of G.  
    *
-   * @return a vector of pairs of sets, where
-   * each pair consists of the vertex set and edge set of a
-   * spanning tree for a connected component of the graph.
+   * @return a vector of adjacency lists, one for each component,
+   * where each adjacency list is implemented as an unordered_map
+   * from nodes in the componenent to vectors of their neighbors.
    */
-  vector<std::pair<set<Node>, set<Edge>>> spanning_forest();
+  vector<unordered_map<Node, vector<Node>>> spanning_forest();
 
   /**
    * An algorithm for testing if the graph is k-edge-connected.

--- a/include/graph.h
+++ b/include/graph.h
@@ -37,6 +37,7 @@ class Graph{
 public:
   explicit Graph(uint64_t num_nodes);
   ~Graph();
+  Graph(const Graph& g);
   void update(GraphUpdate upd);
 
   /**

--- a/include/graph.h
+++ b/include/graph.h
@@ -65,14 +65,17 @@ public:
   vector<unordered_map<Node, vector<Node>>> spanning_forest();
 
   /**
-   * An algorithm for testing if the graph is k-edge-connected.
+   * Let $G$ be the graph represented by this sketch, and define 
+   * $F_i$ for $1 <= i <= k$ as a spanning forest of 
+   * $G - \cup_{j = 1}^{i-1} F_j$, where subtraction between graphs
+   * excludes nodes.
+   *
+   * @param k The number of edge-disjoint spanning forests to take
+   * the union of.
    * 
-   * @param k An int specifying to test for k-edge-connectivity
-   * 
-   * @return a boolean indicating whether or not the graph is
-   * k-edge-connected
+   * @return U $\cup_{i = 1}^{k} F_i$
    */ 
-  bool is_k_edge_connected (int k);
+  vector<vector<Node>> k_edge_disjoint_span_forests_union (int k);
 
 #ifdef VERIFY_SAMPLES_F
   std::string cum_in = "./cum_sample.txt";

--- a/include/graph.h
+++ b/include/graph.h
@@ -73,7 +73,8 @@ public:
    * @param k The number of edge-disjoint spanning forests to take
    * the union of.
    * 
-   * @return U $\cup_{i = 1}^{k} F_i$
+   * @return U $ = \cup_{i = 1}^{k} F_i$. A useful property of U is
+   * that G is k-edge-connected iff U is k-edge-connected.
    */ 
   vector<vector<Node>> k_edge_disjoint_span_forests_union (int k);
 

--- a/include/graph.h
+++ b/include/graph.h
@@ -50,6 +50,27 @@ public:
    */
   vector<set<Node>> connected_components();
 
+  /** 
+   * Implements Boruvka on the graph sketch to find a spanning
+   * forest, where a spanning forest of G is defined as a maximal
+   * acyclic subgraph of G.  
+   *
+   * @return a vector of pairs of sets, where
+   * each pair consists of the vertex set and edge set of a
+   * spanning tree for a connected component of the graph.
+   */
+  vector<std::pair<set<Node>, set<Edge>>> spanning_forest();
+
+  /**
+   * An algorithm for testing if the graph is k-edge-connected.
+   * 
+   * @param k An int specifying to test for k-edge-connectivity
+   * 
+   * @return a boolean indicating whether or not the graph is
+   * k-edge-connected
+   */ 
+  bool is_k_edge_connected ();
+
 #ifdef VERIFY_SAMPLES_F
   std::string cum_in = "./cum_sample.txt";
 

--- a/include/graph.h
+++ b/include/graph.h
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <exception>
 #include <set>
+#include <list>
 #include <fstream>
 #include "supernode.h"
 
@@ -69,7 +70,7 @@ public:
    * @return a boolean indicating whether or not the graph is
    * k-edge-connected
    */ 
-  bool is_k_edge_connected ();
+  bool is_k_edge_connected (int k);
 
 #ifdef VERIFY_SAMPLES_F
   std::string cum_in = "./cum_sample.txt";

--- a/include/graph.h
+++ b/include/graph.h
@@ -29,7 +29,7 @@ class Graph{
   const uint64_t num_nodes;
   bool update_locked = false;
   // a set containing one "representative" from each supernode
-  set<Node>* representatives;
+  map<Node, size_t>* representatives;
   Supernode** supernodes;
   // DSU representation of supernode relationship
   Node* parent;

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -24,6 +24,7 @@ public:
    */
   Supernode(uint64_t n, long seed);
   ~Supernode();
+  Supernode(const Supernode& t);
 
   /**
    * Function to sample an edge from the cut of a supernode.

--- a/supernode.cpp
+++ b/supernode.cpp
@@ -19,11 +19,13 @@ Supernode::~Supernode() {
 }
 
 Supernode::Supernode(const Supernode& t)
-	:sketches{vector<Sketch*>(t.sketches.size())},
-	 idk{t.idx},
+	:sketches{vector<Sketch*>()},
+	 idx{t.idx},
 	 logn{t.logn}
 {
-  for (Sketch* ptr : g.sketches)
+  sketches.reserve(t.sketches.size());
+
+  for (Sketch* ptr : t.sketches)
     sketches.push_back(new Sketch(*ptr));
 }
 

--- a/supernode.cpp
+++ b/supernode.cpp
@@ -18,6 +18,16 @@ Supernode::~Supernode() {
     delete sketches[i];
 }
 
+Supernode::Supernode(const Supernode& t)
+	:sketches{vector<Sketch*>(t.sketches.size())},
+	 idk{t.idx},
+	 logn{t.logn}
+{
+  for (Sketch* ptr : g.sketches)
+    sketches.push_back(new Sketch(*ptr));
+}
+
+
 boost::optional<Edge> Supernode::sample() {
   if (idx == logn) throw OutOfQueriesException();
   vec_t query_idx;

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -219,27 +219,39 @@ TEST(GraphTestSuite, TestSpanningForestOnRandomGraph)
   }
 }
 
-//TEST(GraphTestSuite, TestKConnectivityOnRandomGraphs)
-//{
-//  using namespace boost;
-//
-//  int num_trials = 10;
-//  while (num_trials--) {
-//    generate_stream(
-//	{100,0.5,0.5,0,"./sample.txt","./cum_sample.txt"});
-//    
-//    Graph g = ingest_stream("./sample.txt");
-//    UGraph bg = ingest_cum_graph(".cum_sample.txt");
-//
-//    auto min_cut_size = stoer_wagner_min_cut(bg, 
-//	make_static_property_map<UGraph::edge_descriptor>(1));
-//
-//    std::cout << "Testing " << min_cut_size << "-edge-connectivity on a graph with min edge cut of size " << min_cut_size;
-//
-//    EXPECT_TRUE(g.is_k_edge_connected(min_cut_size));
-////    EXPECT_FALSE(g.is_k_edge_connected(min_cut_size + 1));
-//
-//    // TODO: Ensure any k \in [min_cut_size] returns true, and
-//    // any k > min_cut_size returns false. 
-//  }
-//}
+TEST(GraphTestSuite, CopyTest)
+{
+  generate_stream(
+	{100,0.5,0.5,0,"./sample.txt","./cum_sample.txt"});
+ 
+  Graph g = ingest_stream("./sample.txt");
+  Graph g2{g};
+
+  g.spanning_forest();
+  g2.spanning_forest();
+}
+
+TEST(GraphTestSuite, RandomGraphIsMinCutSizeEdgeConnected)
+{
+  using namespace boost;
+
+  int num_trials = 10;
+  while (num_trials--) {
+    generate_stream(
+	{100,0.5,0.5,0,"./sample.txt","./cum_sample.txt"});
+    
+    Graph g = ingest_stream("./sample.txt");
+    UGraph bg = ingest_cum_graph("./cum_sample.txt");
+
+    auto min_cut_size = stoer_wagner_min_cut(bg, 
+	make_static_property_map<UGraph::edge_descriptor>(1));
+
+    std::cout << "Testing " << min_cut_size << "-edge-connectivity on a graph with min edge cut of size " << min_cut_size;
+
+    EXPECT_TRUE(g.is_k_edge_connected(min_cut_size));
+//    EXPECT_FALSE(g.is_k_edge_connected(min_cut_size + 1));
+
+    // TODO: Ensure any k \in [min_cut_size] returns true, and
+    // any k > min_cut_size returns false. 
+  }
+}

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -4,6 +4,8 @@
 #include "util/graph_verifier.h"
 #include "util/graph_gen.h"
 
+#include <boost/graph/stoer_wagner_min_cut.hpp>
+
 TEST(GraphTestSuite, SmallGraphConnectivity) {
   const std::string fname = __FILE__;
   size_t pos = fname.find_last_of("\\/");
@@ -87,4 +89,47 @@ TEST(GraphTestSuite, TestCorrectnessOnSmallSparseGraphs) {
     g.set_cum_in("./cum_sample.txt");
     g.connected_components();
   }
+}
+
+TEST(GraphTestSuite, TestKConnectivityOnRandomGraphs)
+{
+  using namespace boost;
+  typedef adjacency_list<vecS, vecS, undirectedS> UGraph; 
+
+  int num_trials = 10;
+  while (num_trials--) {
+    generate_stream({100,0.03,0.5,0,"./sample.txt","./cum_sample.txt"});
+    ifstream in{"./sample.txt"};
+    Node n, m;
+    in >> n >> m;
+    
+    Graph g{n};
+    UGraph bg{n};
+
+    int type, a, b;
+    while (m--) 
+    {
+      in >> type >> a >> b;
+      if (type == INSERT) 
+      {
+        g.update({{a, b}, INSERT});
+        add_edge(a, b, bg)
+      } 
+      else 
+      {
+        g.update({{a, b}, DELETE});
+	remove_edge(a, b, bg);
+      }
+    }
+   
+    auto min_cut_size = stoer_wagner_min_cut(bg, 
+	make_static_property_map<UGraph::edge_descriptor>(1));
+
+    EXPECT_TRUE(is_k_edge_connected(min_cut_size));
+    EXPECT_FALSE(is_k_edge_connected(min_cut_size + 1));
+
+    // TODO: Ensure any k \in [min_cut_size] returns true, and
+    // any k > min_cut_size returns false. 
+  }
+
 }

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -250,18 +250,22 @@ TEST(GraphTestSuite, MinCutSizeEdgeConnectedIffHasMinCutSizedSkeleton)
 
     auto U = g.k_edge_disjoint_span_forests_union(G_min_cut_size);
 
-    UGraph bu;
+    UGraph bu(n);
     for (Node i = 0; i < n; i++)
     {
       for (Node neighbor : U[i])
       {
-	ASSERT_FALSE(edge(i, neighbor, bu).second) 
-		<< "Spanning forests are not edge-disjoint";
-	add_edge(i, neighbor, bu);
+	if (i < neighbor)
+        {
+	  ASSERT_FALSE(edge(i, neighbor, bu).second) 
+		  << "Forests are not edge-disjoint \n";
+	  
+          add_edge(i, neighbor, bu);
+        }
       }
     }
 
-    auto F_min_cut_size = stoer_wagner_min_cut(bu, 
+    auto U_min_cut_size = stoer_wagner_min_cut(bu, 
 	make_static_property_map<UGraph::edge_descriptor>(1));
 
     EXPECT_EQ(G_min_cut_size, U_min_cut_size);

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -113,7 +113,7 @@ TEST(GraphTestSuite, TestKConnectivityOnRandomGraphs)
       if (type == INSERT) 
       {
         g.update({{a, b}, INSERT});
-        add_edge(a, b, bg)
+        add_edge(a, b, bg);
       } 
       else 
       {
@@ -125,8 +125,10 @@ TEST(GraphTestSuite, TestKConnectivityOnRandomGraphs)
     auto min_cut_size = stoer_wagner_min_cut(bg, 
 	make_static_property_map<UGraph::edge_descriptor>(1));
 
-    EXPECT_TRUE(is_k_edge_connected(min_cut_size));
-    EXPECT_FALSE(is_k_edge_connected(min_cut_size + 1));
+    std::cout << "Testing " << min_cut_size << "-edge-connectivity on a graph with min edge cut of size " << min_cut_size;
+
+    EXPECT_TRUE(g.is_k_edge_connected(min_cut_size));
+//    EXPECT_FALSE(g.is_k_edge_connected(min_cut_size + 1));
 
     // TODO: Ensure any k \in [min_cut_size] returns true, and
     // any k > min_cut_size returns false. 

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -138,11 +138,16 @@ TEST(GraphTestSuite, TestSpanningForestOnRandomGraph)
 {
   using namespace boost;
   int num_trials = 10;
+  // Probability of edge present between two nodes
+  double p_low_bound = 0.002;
+  double p_up_bound = 0.01;
 
   while (num_trials--)
   {
+    double p = p_low_bound + ((double)rand() / RAND_MAX) * (
+		    p_up_bound - p_low_bound); 
     generate_stream(
-	{1024,0.002,0.5,0,"./sample.txt","./cum_sample.txt"});
+	{1024,p,0.5,0,"./sample.txt","./cum_sample.txt"});
 
     UGraph bg = ingest_cum_graph("./cum_sample.txt");
     auto boost_num_vertices = num_vertices(bg);

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -3,9 +3,13 @@
 #include "../include/graph.h"
 #include "util/graph_verifier.h"
 #include "util/graph_gen.h"
+
 #include <unordered_set>
-#include <boost/graph/stoer_wagner_min_cut.hpp>
 #include <stack>
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/stoer_wagner_min_cut.hpp>
+#include <boost/graph/connected_components.hpp>
 
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> UGraph; 
 
@@ -21,7 +25,7 @@ Graph ingest_stream (std::string filename)
   while (m--) 
   {
     in >> type >> a >> b;
-    g.update({{a, b}, UpdateType{type}});
+    g.update({{a, b}, (UpdateType)type});
   }
 
  return g;
@@ -38,15 +42,12 @@ UGraph ingest_cum_graph (std::string filename)
   int a, b;
   while (m--) 
   {
-    in a >> b;
+    in >> a >> b;
     boost::add_edge(a, b, bg);
   }
  
   return bg;
 }
-
-
-ingest
 
 TEST(GraphTestSuite, SmallGraphConnectivity) {
   const std::string fname = __FILE__;
@@ -141,92 +142,100 @@ TEST(GraphTestSuite, TestSpanningForestOnRandomGraph)
   while (num_trials--)
   {
     generate_stream(
-	{1024,0.03,0.5,0,"./sample.txt","./cum_sample.txt"});
-
-    Graph g = ingest_stream("./sample.txt");  
-    auto F = g.spanning_forest();
+	{1024,0.002,0.5,0,"./sample.txt","./cum_sample.txt"});
 
     UGraph bg = ingest_cum_graph("./cum_sample.txt");
     auto boost_num_vertices = num_vertices(bg);
     vector<int> boost_comp_map(boost_num_vertices);
     int boost_num_comp = 
-	    connected_components(bg, boost_comp_map);
-
+	    connected_components(bg, &boost_comp_map[0]);
     // Store the cardinality of each boost connected component
     vector<int> boost_comp_sizes(boost_num_comp);
     for (Node i = 0; i < boost_num_vertices; i++)
 	    boost_comp_sizes[boost_comp_map[i]]++;
 
-    for (const& auto adj_list : F)
+    std::cout << "Verifying spanning forest on graph with " << boost_num_comp << " CC(s)." << std::endl; 
+
+    Graph g = ingest_stream("./sample.txt");
+    auto F = g.spanning_forest();
+
+    for (const auto& adj_list : F)
     {
-      first_node = adj_list.begin()->first;
+      // TODO: handle empty case
+      Node first_node = adj_list.begin()->first;
+      
       // Identity of the corresponding boost connected component
       int boost_CC_id = boost_comp_map[first_node];
 
       // DFS on current component represented by adj_list
-      unordered_set<Node> visited();
-      visited.reserve(adj_list.size());
-   
-      stack<Node> branch_points();    
+      std::unordered_set<Node> visited;
+      visited.reserve(adj_list.size()); 
+      std::stack<Node> branch_points;    
       branch_points.push(first_node);
-      Node prev;
-
       while (!branch_points.empty())
       {
-        Node cur = branch_points.pop();
+        Node cur = branch_points.top();
+	branch_points.pop();
 
 	// Verify node is present in corresponding boost CC
-	EXPECT_EQ(boost_CC_id, boost_comp_map[cur])
-		<< "Node in wrong component";
+	ASSERT_EQ(boost_CC_id, boost_comp_map[cur])
+		<< "Node in wrong component\n";
 
-	// Cycle detection
-	EXPECT_EQ(visited.count(cur), 0) << "Cycle detected\n";
-        visited.insert(cur);
+	visited.insert(cur);
 
-	for (const Node& neighbor : adj_list[cur])
+	int visited_neighbor_count = 0;
+	for (const Node& neighbor : adj_list.at(cur))
 	{
-	  if (neighbor == prev) continue;
-	  
+	  if (visited.count(neighbor) > 0)
+	  {
+	    visited_neighbor_count++;
+
+	    // If we've already visited more than one neighbor of
+	    // the current node, then we have found a cycle
+	    if (visited_neighbor_count > 1)
+	      FAIL() << "Cycle detected\n";
+
+	    continue;  
+	  }
+
 	  // Verify that spanning forest is subgraph
 	  bool edge_exists = edge(cur, neighbor, bg).second;
-	  EXPECT_TRUE(edge_exists) 
+	  ASSERT_TRUE(edge_exists) 
 		  << "Edge does not exist in supergraph\n";
 	  
 	  branch_points.push(neighbor);
 	}
-
-	prev = cur;
       }
 
-      // Ensure cardinality of boost_CC and adj_list vertex set
-      // are equal.
-      EXPECT_EQ(adj_list.size(), boost_comp_sizes[boost_CC_id]) 
+      // Ensure cardinality of boost_CC and visited vertex set
+      // are equal (i.e. that the forest is spanning on this CC)
+      ASSERT_EQ(visited.size(), boost_comp_sizes[boost_CC_id]) 
 	      << "Incorrect component size \n";
     }  
   }
 }
 
-TEST(GraphTestSuite, TestKConnectivityOnRandomGraphs)
-{
-  using namespace boost;
-
-  int num_trials = 10;
-  while (num_trials--) {
-    generate_stream(
-	{100,0.5,0.5,0,"./sample.txt","./cum_sample.txt"});
-    
-    Graph g = ingest_stream("./sample.txt");
-    UGraph bg = ingest_cum_graph(".cum_sample.txt");
-
-    auto min_cut_size = stoer_wagner_min_cut(bg, 
-	make_static_property_map<UGraph::edge_descriptor>(1));
-
-    std::cout << "Testing " << min_cut_size << "-edge-connectivity on a graph with min edge cut of size " << min_cut_size;
-
-    EXPECT_TRUE(g.is_k_edge_connected(min_cut_size));
-//    EXPECT_FALSE(g.is_k_edge_connected(min_cut_size + 1));
-
-    // TODO: Ensure any k \in [min_cut_size] returns true, and
-    // any k > min_cut_size returns false. 
-  }
-}
+//TEST(GraphTestSuite, TestKConnectivityOnRandomGraphs)
+//{
+//  using namespace boost;
+//
+//  int num_trials = 10;
+//  while (num_trials--) {
+//    generate_stream(
+//	{100,0.5,0.5,0,"./sample.txt","./cum_sample.txt"});
+//    
+//    Graph g = ingest_stream("./sample.txt");
+//    UGraph bg = ingest_cum_graph(".cum_sample.txt");
+//
+//    auto min_cut_size = stoer_wagner_min_cut(bg, 
+//	make_static_property_map<UGraph::edge_descriptor>(1));
+//
+//    std::cout << "Testing " << min_cut_size << "-edge-connectivity on a graph with min edge cut of size " << min_cut_size;
+//
+//    EXPECT_TRUE(g.is_k_edge_connected(min_cut_size));
+////    EXPECT_FALSE(g.is_k_edge_connected(min_cut_size + 1));
+//
+//    // TODO: Ensure any k \in [min_cut_size] returns true, and
+//    // any k > min_cut_size returns false. 
+//  }
+//}

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -161,7 +161,6 @@ TEST(GraphTestSuite, TestSpanningForestOnRandomGraph)
 
     for (const auto& adj_list : F)
     {
-      // TODO: handle empty case
       Node first_node = adj_list.begin()->first;
       
       // Identity of the corresponding boost connected component

--- a/test/util/graph_verifier.cpp
+++ b/test/util/graph_verifier.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <map>
 #include "graph_verifier.h"
+#include <algorithm>
 
 //Node* parent;
 //Node* size;


### PR DESCRIPTION
Added a method in the Graph class to find the union of k edge-disjoint spanning forests as required by the k-edge-connectivity algorithm presented in the original paper. 
Added a method in the Graph class to compute a spanning forest from the graph sketch (used as a subroutine in the above).
Added the copy constructors necessary for the duplication of Graph objects (needed for the above).
Added tests for each aforementioned addition.