### PR TITLE
implicit syncing of sketch::operator+=

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ ExternalProject_Add(
 
   PREFIX          BufferTree
   GIT_REPOSITORY  "https://github.com/Victor-C-Zhang/FastBufferTree.git"
-  GIT_TAG         "main"
+  GIT_TAG         "circular_queue"
 
   BUILD_ALWAYS    OFF
   INSTALL_DIR     ${CMAKE_CURRENT_BINARY_DIR}/BufferTree/prefix

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -24,8 +24,6 @@ class Sketch {
   const vec_t n;
   // Factor for how many buckets there are in this sketch.
   const double num_bucket_factor;
-  // Lock to ensure sequential write access to sketches
-  std::mutex sketch_mt;
 
   // Buckets of this sketch.
   // Length is bucket_gen(n, num_bucket_factor) * guess_gen(n).
@@ -47,6 +45,7 @@ public:
    * @param num_bucket_factor Factor to scale the number of buckets in this sketch
    */
   Sketch(vec_t n, long seed, double num_bucket_factor = 1);
+  Sketch(const Sketch &old);
 
   /**
    * Update a sketch based on information about one of its indices.
@@ -55,7 +54,7 @@ public:
   void update(const vec_t& update_idx);
 
   /**
-   * Update a sketch given a batch of updates
+   * Update a sketch given a batch of updates.
    * @param updates A vector of updates
    */
   void batch_update(const std::vector<vec_t>& updates);

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -3,6 +3,7 @@
 #include <exception>
 #include <iostream>
 #include <vector>
+#include <mutex>
 #include "bucket.h"
 #include "types.h"
 #include "util.h"
@@ -23,6 +24,9 @@ class Sketch {
   const vec_t n;
   // Factor for how many buckets there are in this sketch.
   const double num_bucket_factor;
+  // Lock to ensure sequential write access to sketches
+  std::mutex sketch_mt;
+
   // Buckets of this sketch.
   // Length is bucket_gen(n, num_bucket_factor) * guess_gen(n).
   // For buckets[i * guess_gen(n) + j], the bucket has a 1/2^j probability
@@ -65,6 +69,14 @@ public:
    */
   vec_t query();
 
+  /**
+   * Operator to add a sketch to another one in-place. Guaranteed to be
+   * thread-safe for the sketch being added to. It is up to the user to
+   * handle concurrency of the other sketch.
+   * @param sketch1 the one being added to.
+   * @param sketch2 the one being added.
+   * @return a reference to the combined sketch.
+   */
   friend Sketch &operator+= (Sketch &sketch1, const Sketch &sketch2);
   friend bool operator== (const Sketch &sketch1, const Sketch &sketch2);
   friend std::ostream& operator<< (std::ostream &os, const Sketch &sketch);

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -17,8 +17,10 @@ class Supernode {
   vector<Sketch*> sketches;
   int idx;
   int logn;
+  std::mutex node_mt;
 
   FRIEND_TEST(SupernodeTestSuite, TestBatchUpdate);
+  FRIEND_TEST(SupernodeTestSuite, TestConcurrency);
   FRIEND_TEST(EXPR_Parallelism, N10kU100k);
 
 public:

--- a/supernode.cpp
+++ b/supernode.cpp
@@ -68,7 +68,7 @@ void Supernode::batch_update(const std::vector<vec_t>& updates) {
    * this was slow (at least on small graph inputs).
    */
   std::vector<Sketch*> deltas(logn);
-  #pragma omp parallel for num_threads(GraphWorker::get_group_size())
+  #pragma omp parallel for num_threads(GraphWorker::get_group_size()) default(none) shared(deltas, updates)
   for (unsigned i = 0; i < sketches.size(); ++i) {
     deltas[i] = new Sketch(*sketches[i]);
     deltas[i]->batch_update(updates);

--- a/supernode.cpp
+++ b/supernode.cpp
@@ -67,8 +67,18 @@ void Supernode::batch_update(const std::vector<vec_t>& updates) {
    * Considered using spin-threads and parallelism within sketch::update, but
    * this was slow (at least on small graph inputs).
    */
+  std::vector<Sketch*> deltas(logn);
   #pragma omp parallel for num_threads(GraphWorker::get_group_size())
   for (unsigned i = 0; i < sketches.size(); ++i) {
-    sketches[i]->batch_update(updates);
+    deltas[i] = new Sketch(*sketches[i]);
+    deltas[i]->batch_update(updates);
+  }
+  std::unique_lock<std::mutex> lk(node_mt);
+  for (unsigned i = 0; i < sketches.size(); ++i) {
+    *sketches[i] += *deltas[i];
+  }
+  lk.unlock();
+  for (unsigned i = 0; i < sketches.size(); ++i) {
+    delete deltas[i];
   }
 }


### PR DESCRIPTION
As advertised on the tin.

Adds an extra 40 bytes of overhead to a `Sketch` object. We should discuss if this is amenable.