### PR TITLE
Chore: bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,7 @@ add_executable(tests
   l0_sampling/update.cpp
   util.cpp)
 target_link_libraries(tests PRIVATE xxHash::xxhash GTest::gtest)
-target_compile_definitions(tests PRIVATE VERIFY_SAMPLES_F USE_NATIVE_F
-    USE_FBT_F)
+target_compile_definitions(tests PRIVATE VERIFY_SAMPLES_F USE_FBT_F)
 # dependencies
 add_dependencies(tests BufferTree)
 target_link_libraries(tests PRIVATE libFastBufferTree.a)
@@ -228,7 +227,7 @@ add_executable(mem_tests
     l0_sampling/update.cpp
     util.cpp)
 target_link_libraries(mem_tests PRIVATE xxHash::xxhash GTest::gtest)
-target_compile_definitions(mem_tests PRIVATE VERIFY_SAMPLES_F USE_NATIVE_F)
+target_compile_definitions(mem_tests PRIVATE VERIFY_SAMPLES_F)
 # dependencies
 add_dependencies(mem_tests BufferTree)
 target_link_libraries(mem_tests PRIVATE libFastBufferTree.a)

--- a/graph.cpp
+++ b/graph.cpp
@@ -26,9 +26,11 @@ Graph::Graph(uint64_t num_nodes): num_nodes(num_nodes) {
   bf = new BufferTree(buffer_loc_prefix, (1<<20), 8, num_nodes, GraphWorker::get_num_groups(), true);
   GraphWorker::start_workers(this, bf);
 #else
+  unsigned num_buckets = bucket_gen(num_nodes*num_nodes, 1); // TODO: don't fix num_bucket_factor
+  unsigned num_guesses = guess_gen(num_nodes*num_nodes);
   unsigned node_size = sizeof(Supernode) + double_to_ull(log2(num_nodes))*(
-        sizeof(Sketch) + bucket_gen(num_nodes*num_nodes, 1)*sizeof(vec_t) +
-        guess_gen(num_nodes)*sizeof(vec_hash_t));
+        sizeof(Sketch)
+        + num_buckets*num_guesses*(sizeof(vec_t) + sizeof(vec_hash_t)));
   wq = new WorkQueue(node_size, num_nodes, 2*GraphWorker::get_num_groups());
   GraphWorker::start_workers(this, wq);
 #endif

--- a/test/supernode_test.cpp
+++ b/test/supernode_test.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <thread>
 #include "../include/supernode.h"
+#include "../include/graph_worker.h"
 
 const long seed = 7000000001;
 const unsigned long long int num_nodes = 2000;
@@ -185,7 +186,9 @@ TEST_F(SupernodeTestSuite, TestBatchUpdate) {
 }
 
 TEST_F(SupernodeTestSuite, TestConcurrency) {
-  unsigned num_threads = std::thread::hardware_concurrency() - 1; // hyperthreading?
+  int num_threads_per_group = 2;
+  unsigned num_threads =
+        std::thread::hardware_concurrency() / num_threads_per_group - 1; // hyperthreading?
   unsigned vec_len = 1000000;
   unsigned num_updates = 100000;
 
@@ -200,6 +203,9 @@ TEST_F(SupernodeTestSuite, TestConcurrency) {
 
   Supernode supernode(vec_len, seed);
   Supernode piecemeal(vec_len, seed);
+
+  GraphWorker::set_config(0,num_threads_per_group); // set number of threads per omp
+  // parallel
 
   // concurrently run batch_updates
   std::thread thd[num_threads];


### PR DESCRIPTION
- Correct size of nodes in in-memory buffering system (thanks @etwest for pointing this out)
- Use correct size types for vec_t and vec_hash_t (64, 32 respectively)
- Add OpenMP parallelization for `SupernodeTestSuite.TestConcurrency`