### PR TITLE
Improvements to Connected Components Performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ FetchContent_Declare(
   GutterTree
 
   GIT_REPOSITORY  "https://github.com/GraphStreamingProject/GutterTree.git"
-  GIT_TAG         "size-parallel-optimizations"
+  GIT_TAG         "main"
 
   UPDATE_DISCONNECTED OFF
   CMAKE_CACHE_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ FetchContent_Declare(
   GutterTree
 
   GIT_REPOSITORY  "https://github.com/GraphStreamingProject/GutterTree.git"
-  GIT_TAG         "main"
+  GIT_TAG         "size-parallel-optimizations"
 
   UPDATE_DISCONNECTED OFF
   CMAKE_CACHE_ARGS

--- a/include/bucket.h
+++ b/include/bucket.h
@@ -67,11 +67,10 @@ inline col_hash_t Bucket_Boruvka::col_index_hash(const vec_t& update_idx, const 
 
 inline vec_hash_t Bucket_Boruvka::index_hash(const vec_t& index, long sketch_seed) {
   return vec_hash(&index, sizeof(index), sketch_seed);
-
 }
 
-inline bool Bucket_Boruvka::contains(const col_hash_t& col_index_hash, const vec_t& guess_nonzero) {
-  return col_index_hash % guess_nonzero == 0;
+inline bool Bucket_Boruvka::contains(const col_hash_t& col_index_hash, const col_hash_t& guess_nonzero) {
+  return (col_index_hash & guess_nonzero) == 0;
 }
 
 inline bool Bucket_Boruvka::is_good(const vec_t& a, const vec_hash_t& c, const long& sketch_seed) {

--- a/include/bucket.h
+++ b/include/bucket.h
@@ -26,7 +26,7 @@ namespace Bucket_Boruvka {
   /**
    * Checks whether the hash associated with the Bucket hashes the index to 0.
    * @param col_index_hash The return value to Bucket::col_index_hash
-   * @param guess_nonzero A power of 2, used as a modulus
+   * @param guess_nonzero A power of 2, used to check if a specific bit value is non-zero
    * @return true if the index is NOT hashed to zero mod guess_nonzero.
    */
   inline static bool contains(const col_hash_t& col_index_hash, const vec_t& guess_nonzero);
@@ -70,7 +70,7 @@ inline vec_hash_t Bucket_Boruvka::index_hash(const vec_t& index, long sketch_see
 }
 
 inline bool Bucket_Boruvka::contains(const col_hash_t& col_index_hash, const col_hash_t& guess_nonzero) {
-  return (col_index_hash & guess_nonzero) == 0;
+  return (col_index_hash & guess_nonzero) == 0; // use guess_nonzero (power of 2) to check ith bit
 }
 
 inline bool Bucket_Boruvka::is_good(const vec_t& a, const vec_hash_t& c, const long& sketch_seed) {

--- a/include/graph.h
+++ b/include/graph.h
@@ -38,6 +38,9 @@ class Graph {
   Supernode** backup_supernodes();
   void restore_supernodes(Supernode** supernodes);
 
+  std::string backup_file; // where to backup the supernodes
+  bool copy_in_mem = false; // should backups be made in memory or on disk
+
   FRIEND_TEST(GraphTestSuite, TestCorrectnessOfReheating);
   static bool open_graph;
 public:
@@ -109,6 +112,7 @@ public:
   std::chrono::steady_clock::time_point create_backup_end;
   std::chrono::steady_clock::time_point restore_backup_start;
   std::chrono::steady_clock::time_point restore_backup_end;
+
 };
 
 class UpdateLockedException : public std::exception {

--- a/include/graph.h
+++ b/include/graph.h
@@ -17,6 +17,20 @@ class GraphWorker;
 
 typedef std::pair<Edge, UpdateType> GraphUpdate;
 
+// Exceptions the Graph class may throw
+class UpdateLockedException : public std::exception {
+  virtual const char* what() const throw() {
+    return "The graph cannot be updated: Connected components algorithm has "
+           "already started";
+  }
+};
+
+class MultipleGraphsException : public std::exception {
+  virtual const char * what() const throw() {
+    return "Only one Graph may be open at one time. The other Graph must be deleted.";
+  }
+};
+
 /**
  * Undirected graph object with n nodes labelled 0 to n-1, no self-edges,
  * multiple edges, or weights.
@@ -49,7 +63,7 @@ public:
 
   ~Graph();
 
-  inline void Graph::update(GraphUpdate upd) {
+  inline void update(GraphUpdate upd) {
     if (update_locked) throw UpdateLockedException();
     Edge &edge = upd.first;
 
@@ -120,18 +134,5 @@ public:
   std::chrono::steady_clock::time_point create_backup_end;
   std::chrono::steady_clock::time_point restore_backup_start;
   std::chrono::steady_clock::time_point restore_backup_end;
-};
-
-class UpdateLockedException : public std::exception {
-  virtual const char* what() const throw() {
-    return "The graph cannot be updated: Connected components algorithm has "
-           "already started";
-  }
-};
-
-class MultipleGraphsException : public std::exception {
-  virtual const char * what() const throw() {
-    return "Only one Graph may be open at one time. The other Graph must be deleted.";
-  }
 };
 

--- a/include/graph.h
+++ b/include/graph.h
@@ -48,7 +48,15 @@ public:
   explicit Graph(const std::string &input_file);
 
   ~Graph();
-  void update(GraphUpdate upd);
+
+  inline void Graph::update(GraphUpdate upd) {
+    if (update_locked) throw UpdateLockedException();
+    Edge &edge = upd.first;
+
+    bf->insert(edge);
+    std::swap(edge.first, edge.second);
+    bf->insert(edge);
+  }
 
   /**
    * Update all the sketches in supernode, given a batch of updates.

--- a/include/graph.h
+++ b/include/graph.h
@@ -49,8 +49,14 @@ class Graph {
   // Buffering system for batching updates
   BufferingSystem *bf;
 
-  Supernode** backup_supernodes();
-  void restore_supernodes(Supernode** supernodes);
+  void backup_to_disk();
+  void restore_from_disk();
+
+  /**
+   * Main parallel algorithm utilizing Boruvka and L_0 sampling.
+   * @return a vector of the connected components in the graph.
+   */
+  std::vector<std::set<node_id_t>> boruvka_emulation(bool make_copy);
 
   std::string backup_file; // where to backup the supernodes
   bool copy_in_mem = false; // should backups be made in memory or on disk
@@ -80,12 +86,6 @@ public:
    *                   supernode.
    */
   void batch_update(node_id_t src, const std::vector<size_t> &edges, Supernode *delta_loc);
-
-  /**
-   * Main parallel algorithm utilizing Boruvka and L_0 sampling.
-   * @return a vector of the connected components in the graph.
-   */
-  std::vector<std::set<node_id_t>> boruvka_emulation();
 
   /**
    * Main parallel algorithm utilizing Boruvka and L_0 sampling.

--- a/include/graph.h
+++ b/include/graph.h
@@ -101,7 +101,14 @@ public:
    */
   void write_binary(const std::string &filename);
 
-  std::chrono::steady_clock::time_point end_time;
+  std::chrono::steady_clock::time_point flush_call;
+  std::chrono::steady_clock::time_point flush_return;
+  std::chrono::steady_clock::time_point cc_alg_start;
+  std::chrono::steady_clock::time_point cc_alg_end;
+  std::chrono::steady_clock::time_point create_backup_start;
+  std::chrono::steady_clock::time_point create_backup_end;
+  std::chrono::steady_clock::time_point restore_backup_start;
+  std::chrono::steady_clock::time_point restore_backup_end;
 };
 
 class UpdateLockedException : public std::exception {

--- a/include/graph.h
+++ b/include/graph.h
@@ -49,8 +49,8 @@ class Graph {
   // Buffering system for batching updates
   BufferingSystem *bf;
 
-  void backup_to_disk();
-  void restore_from_disk();
+  void backup_to_disk(std::vector<node_id_t> ids_to_backup);
+  void restore_from_disk(std::vector<node_id_t> ids_to_restore);
 
   /**
    * Main parallel algorithm utilizing Boruvka and L_0 sampling.

--- a/include/l0_sampling/sketch.h
+++ b/include/l0_sampling/sketch.h
@@ -41,7 +41,7 @@ private:
   vec_hash_t* bucket_c;
 
   // Flag to keep track if this sketch has already been queried.
-  bool already_quered = false;
+  bool already_queried = false;
 
   FRIEND_TEST(SketchTestSuite, TestExceptions);
   FRIEND_TEST(EXPR_Parallelism, N10kU100k);
@@ -96,6 +96,10 @@ public:
   
   inline static vec_t get_failure_factor() 
   { return failure_factor; }
+
+  inline void reset_queried() 
+  { already_queried = false; }
+
   /**
    * Update a sketch based on information about one of its indices.
    * @param update the point update.

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -85,6 +85,15 @@ public:
     return bytes_size;
   }
 
+  // reset the supernode query metadata
+  // we use this when resuming insertions after CC made copies in memory
+  inline void reset_query_state() { 
+    for (int i = 0; i < idx; i++) {
+      get_sketch(i)->reset_queried();
+    }
+    idx = 0;
+  }
+
   /**
    * Function to sample an edge from the cut of a supernode.
    * @return   an edge in the cut, represented as an Edge with LHS <= RHS, 

--- a/include/test/write_configuration.h
+++ b/include/test/write_configuration.h
@@ -1,16 +1,17 @@
 #include <fstream>
 
-static void write_configuration(bool use_tree, int groups=1, int g_size=1) {
+static void write_configuration(bool use_tree, bool backup_in_mem=false, int groups=1, int g_size=1) {
 	// read previous configuration to get GutterTree prefix
 	// as this is system dependent and shouldn't be set by our code
 	std::ifstream in("streaming.conf");
-	std::string path_prefix;
+	std::string disk_dir = ".";
 	if (in.is_open()) {
 		std::string line;
 		while(getline(in, line)) {
 			if (line[0] == '#' || line[0] == '\n') continue;
-			if (line.substr(0, line.find('=')) == "path_prefix") {
-				path_prefix = line.substr(line.find('=') + 1);
+			if (line.substr(0, line.find('=')) == "disk_dir") {
+				disk_dir = line.substr(line.find('=') + 1);
+				if (disk_dir == "") disk_dir = ".";
 				break;
 			}
 		}
@@ -19,7 +20,8 @@ static void write_configuration(bool use_tree, int groups=1, int g_size=1) {
 
 	std::ofstream out("streaming.conf");
 	out << "buffering_system=" << (use_tree? "tree" : "standalone") << std::endl;
-	out << "path_prefix=" << path_prefix << std::endl;
+	out << "disk_dir=" << disk_dir << std::endl;
+	out << "backup_in_mem=" << (backup_in_mem? "ON" : "OFF") << std::endl;
 	out << "num_groups=" << groups << std::endl;
 	out << "group_size=" << g_size << std::endl;
 	out.close();

--- a/include/types.h
+++ b/include/types.h
@@ -2,9 +2,9 @@
 #include <xxhash.h>
 #include <graph_zeppelin_common.h>
 
-typedef vec_hash_t col_hash_t;
+typedef uint64_t col_hash_t;
 static const auto& vec_hash = XXH32;
-static const auto& col_hash = XXH32;
+static const auto& col_hash = XXH64;
 
 enum UpdateType {
   INSERT = 0,

--- a/include/util.h
+++ b/include/util.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <tuple>
 
 /**
  * Cast a double to unsigned long long with epsilon adjustment.
@@ -25,6 +26,9 @@ std::pair<uint32_t , uint32_t> inv_nondir_non_self_edge_pairing_fn(uint64_t idx)
  * Gets the path prefix where the buffer tree data will be stored and sets
  * with the number of threads used for a variety of tasks.
  * Should be called before creating the buffer tree or starting graph workers.
- * @return the prefix of the path in which the buffer tree should be stored.
+ * @return a tuple with the following elements
+ *   - use_guttertree
+ *   - in_memory_backups
+ *   - disk_dir
  */
-std::pair<bool, std::string> configure_system();
+std::tuple<bool, bool, std::string> configure_system();

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -33,11 +33,12 @@ Graph::Graph(node_id_t num_nodes): num_nodes(num_nodes) {
   }
   num_updates = 0; // REMOVE this later
   
-  std::pair<bool, std::string> conf = configure_system(); // read the configuration file to configure the system
-  std::string disk_loc = conf.second;
+  std::tuple<bool, bool, std::string> conf = configure_system(); // read the configuration file to configure the system
+  copy_in_mem = std::get<1>(conf);
+  std::string disk_loc = std::get<2>(conf);
   backup_file = disk_loc + "supernode_backup.data";
   // Create the buffering system and start the graphWorkers
-  if (conf.first)
+  if (std::get<0>(conf))
     bf = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
     bf = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
@@ -69,11 +70,12 @@ Graph::Graph(const std::string& input_file) : num_updates(0) {
   }
   binary_in.close();
 
-  std::pair<bool, std::string> conf = configure_system(); // read the configuration file to configure the system
-  std::string disk_loc = conf.second;
+  std::tuple<bool, bool, std::string> conf = configure_system(); // read the configuration file to configure the system
+  copy_in_mem = std::get<1>(conf);
+  std::string disk_loc = std::get<2>(conf);
   backup_file = disk_loc + "supernode_backup.data";
   // Create the buffering system and start the graphWorkers
-  if (conf.first)
+  if (std::get<0>(conf))
     bf = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
     bf = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
@@ -91,15 +93,6 @@ Graph::~Graph() {
   GraphWorker::stop_workers(); // join the worker threads
   delete bf;
   open_graph = false;
-}
-
-void Graph::update(GraphUpdate upd) {
-  if (update_locked) throw UpdateLockedException();
-  Edge &edge = upd.first;
-
-  bf->insert(edge);
-  std::swap(edge.first, edge.second);
-  bf->insert(edge);
 }
 
 void Graph::generate_delta_node(node_id_t node_n, long node_seed, node_id_t

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -217,6 +217,7 @@ std::vector<std::set<node_id_t>> Graph::boruvka_emulation() {
 }
 
 Supernode** Graph::backup_supernodes() {
+  std::cout << "Backing up supernodes" << std::endl;
   if (copy_in_mem) {
     // Copy supernodes
     Supernode** copy_supernodes = new Supernode*[num_nodes];

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -118,7 +118,7 @@ void Graph::batch_update(node_id_t src, const std::vector<size_t> &edges, Supern
   supernodes[src]->apply_delta_update(delta_loc);
 }
 
-std::vector<std::set<node_id_t>> Graph::boruvka_emulation(const bool make_copy) {
+std::vector<std::set<node_id_t>> Graph::boruvka_emulation(bool make_copy) {
   cc_alg_start = std::chrono::steady_clock::now();
   printf("Total number of updates to sketches before CC %lu\n", num_updates.load()); // REMOVE this later
   update_locked = true; // disallow updating the graph after we run the alg

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -220,7 +220,8 @@ std::vector<std::set<node_id_t>> Graph::boruvka_emulation(bool make_copy) {
 
     // loop over the to_merge vector and perform supernode merging
     #pragma omp parallel for default(none) shared(first_round, make_copy, copy_supernodes, new_reps, to_merge, except, err)
-    for (node_id_t a : new_reps) {
+    for (node_id_t i = 0; i < new_reps.size(); i++) {
+      node_id_t a = new_reps[i]; // fix for ubuntu18.04 ('for each' style in omp no good)
       try {
         if (make_copy && first_round && copy_in_mem) // make a copy of a
           copy_supernodes[a] = Supernode::makeSupernode(*supernodes[a]);
@@ -254,8 +255,7 @@ std::vector<std::set<node_id_t>> Graph::boruvka_emulation(bool make_copy) {
     if(copy_in_mem) {
       // restore original supernodes and free memory
       for (node_id_t i : backed_up) {
-        if (supernodes[i] != nullptr) 
-          free(supernodes[i]);
+        if (supernodes[i] != nullptr) free(supernodes[i]);
         supernodes[i] = copy_supernodes[i];
       }
       delete[] copy_supernodes;

--- a/src/l0_sampling/sketch.cpp
+++ b/src/l0_sampling/sketch.cpp
@@ -75,10 +75,10 @@ void Sketch::batch_update(const std::vector<vec_t>& updates) {
 }
 
 std::pair<vec_t, SampleSketchRet> Sketch::query() {
-  if (already_quered) {
+  if (already_queried) {
     throw MultipleQueryException();
   }
-  already_quered = true;
+  already_queried = true;
 
   if (bucket_a[num_elems - 1] == 0 && bucket_c[num_elems - 1] == 0) {
     return {0, ZERO}; // the "first" bucket is deterministic so if it is all zero then there are no edges to return
@@ -103,12 +103,12 @@ Sketch &operator+= (Sketch &sketch1, const Sketch &sketch2) {
     sketch1.bucket_a[i] ^= sketch2.bucket_a[i];
     sketch1.bucket_c[i] ^= sketch2.bucket_c[i];
   }
-  sketch1.already_quered = sketch1.already_quered || sketch2.already_quered;
+  sketch1.already_queried = sketch1.already_queried || sketch2.already_queried;
   return sketch1;
 }
 
 bool operator== (const Sketch &sketch1, const Sketch &sketch2) {
-  if (sketch1.seed != sketch2.seed || sketch1.already_quered != sketch2.already_quered) 
+  if (sketch1.seed != sketch2.seed || sketch1.already_queried != sketch2.already_queried) 
     return false;
 
   for (size_t i = 0; i < Sketch::num_elems; ++i) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -31,9 +31,10 @@ std::pair<ul, ul> inv_nondir_non_self_edge_pairing_fn(ull idx) {
 
 std::pair<bool, std::string> configure_system() {
   bool use_guttertree = true;
-  std::string pre = "./GUTTREEDATA/";
+  std::string dir = "./";
   int num_groups = 1;
   int group_size = 1;
+  bool backup_in_mem = false;
   std::string line;
   std::ifstream conf(config_file);
   if (conf.is_open()) {
@@ -47,11 +48,19 @@ std::pair<bool, std::string> configure_system() {
           printf("WARNING: string %s is not a valid option for " 
                 "buffering. Defaulting to GutterTree.\n", buf_str.c_str());
         }
-        printf("Using %s for buffering.\n", use_guttertree? "GutterTree" : "StandAloneGutters");
       }
-      if(line.substr(0, line.find('=')) == "path_prefix" && use_guttertree) {
-        pre = line.substr(line.find('=') + 1);
-        printf("GutterTree path_prefix = %s\n", pre.c_str());
+      if(line.substr(0, line.find('=')) == "disk_dir") {
+        dir = line.substr(line.find('=') + 1) + "/";
+      }
+      if(line.substr(0, line.find('=')) == "backup_in_mem") {
+        std::string flag = line.substr(line.find('=') + 1);
+	if (flag == "ON")
+          backup_in_mem = true;
+	else if (flag == "OFF")
+          backup_in_mem = false;
+	else
+          printf("WARNING: string %s is not a valid option for backup_in_mem"
+                 "Defaulting to OFF.\n", flag.c_str());
       }
       if(line.substr(0, line.find('=')) == "num_groups") {
         num_groups = std::stoi(line.substr(line.find('=') + 1));
@@ -59,7 +68,6 @@ std::pair<bool, std::string> configure_system() {
           printf("num_groups=%i is out of bounds. Defaulting to 1.\n", num_groups);
           num_groups = 1; 
         }
-        printf("Number of groups = %i\n", num_groups);
       }
       if(line.substr(0, line.find('=')) == "group_size") {
         group_size = std::stoi(line.substr(line.find('=') + 1));
@@ -67,13 +75,18 @@ std::pair<bool, std::string> configure_system() {
           printf("group_size=%i is out of bounds. Defaulting to 1.\n", group_size);
           group_size = 1; 
         }
-        printf("Size of groups = %i\n", group_size);
       }
     }
   } else {
     printf("WARNING: Could not open thread configuration file! Using default values.\n");
   }
-
+  
+  printf("Configuration:\n");
+  printf("Buffering system = %s\n", use_guttertree? "GutterTree" : "StandAloneGutters");
+  printf("Number of groups = %i\n", num_groups);
+  printf("Size of groups = %i\n", group_size);
+  printf("Directory for on disk data = %s\n", dir.c_str());
+  printf("Query backups in memory = %s\n", backup_in_mem? "ON" : "OFF");
   GraphWorker::set_config(num_groups, group_size);
-  return {use_guttertree, pre};
+  return {use_guttertree, dir};
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,7 +29,7 @@ std::pair<ul, ul> inv_nondir_non_self_edge_pairing_fn(ull idx) {
   return {i, j};
 }
 
-std::pair<bool, std::string> configure_system() {
+std::tuple<bool, bool, std::string> configure_system() {
   bool use_guttertree = true;
   std::string dir = "./";
   int num_groups = 1;
@@ -88,5 +88,5 @@ std::pair<bool, std::string> configure_system() {
   printf("Directory for on disk data = %s\n", dir.c_str());
   printf("Query backups in memory = %s\n", backup_in_mem? "ON" : "OFF");
   GraphWorker::set_config(num_groups, group_size);
-  return {use_guttertree, dir};
+  return {use_guttertree, backup_in_mem, dir};
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -30,11 +30,11 @@ std::pair<ul, ul> inv_nondir_non_self_edge_pairing_fn(ull idx) {
 }
 
 std::tuple<bool, bool, std::string> configure_system() {
-  bool use_guttertree = true;
+  bool use_guttertree = false;
   std::string dir = "./";
   int num_groups = 1;
   int group_size = 1;
-  bool backup_in_mem = false;
+  bool backup_in_mem = true;
   std::string line;
   std::ifstream conf(config_file);
   if (conf.is_open()) {
@@ -46,7 +46,7 @@ std::tuple<bool, bool, std::string> configure_system() {
           use_guttertree = false;
         } else if (buf_str != "tree") {
           printf("WARNING: string %s is not a valid option for " 
-                "buffering. Defaulting to GutterTree.\n", buf_str.c_str());
+                "buffering. Defaulting to StandAloneGutters.\n", buf_str.c_str());
         }
       }
       if(line.substr(0, line.find('=')) == "disk_dir") {
@@ -60,7 +60,7 @@ std::tuple<bool, bool, std::string> configure_system() {
           backup_in_mem = false;
 	else
           printf("WARNING: string %s is not a valid option for backup_in_mem"
-                 "Defaulting to OFF.\n", flag.c_str());
+                 "Defaulting to ON.\n", flag.c_str());
       }
       if(line.substr(0, line.find('=')) == "num_groups") {
         num_groups = std::stoi(line.substr(line.find('=') + 1));

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -151,6 +151,8 @@ TEST_P(GraphTest, TestCorrectnessOfReheating) {
   }
 }
 
+// Test the multithreaded system by specifiying multiple
+// Graph Workers of size 2. Ingest a stream and run CC algorithm.
 TEST_P(GraphTest, MultipleInserters) {
   write_configuration(GetParam(), false, 4, 2);
   int num_trials = 5;

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -68,9 +68,7 @@ TEST_P(GraphTest, IFconnectedComponentsAlgRunTHENupdateLocked) {
 
 TEST_P(GraphTest, TestCorrectnessOnSmallRandomGraphs) {
   write_configuration(GetParam());
-  int num_trials = 10;
-  int allow_fail = 2; // allow 2 failures
-  int fails = 0;
+  int num_trials = 5;
   while (num_trials--) {
     generate_stream();
     std::ifstream in{"./sample.txt"};
@@ -87,24 +85,14 @@ TEST_P(GraphTest, TestCorrectnessOnSmallRandomGraphs) {
     }
 
     g.set_verifier(std::make_unique<FileGraphVerifier>("./cumul_sample.txt"));
-    try {
-      g.connected_components();
-    } catch (OutOfQueriesException& err) {
-      fails++;
-      if (fails > allow_fail) {
-        printf("More than %i failures failing test\n", allow_fail);
-        throw;
-      }
-    }
+    g.connected_components();
   }
 }
 
 TEST_P(GraphTest, TestCorrectnessOnSmallSparseGraphs) {
   write_configuration(GetParam());
-  int num_trials = 10;
-  int allow_fail = 2; // allow 2 failures
-  int fails = 0;
-  while (num_trials--) {
+  int num_trials = 5;
+  while(num_trials--) {
     generate_stream({1024,0.002,0.5,0,"./sample.txt","./cumul_sample.txt"});
     std::ifstream in{"./sample.txt"};
     node_id_t n;
@@ -120,23 +108,13 @@ TEST_P(GraphTest, TestCorrectnessOnSmallSparseGraphs) {
     }
 
     g.set_verifier(std::make_unique<FileGraphVerifier>("./cumul_sample.txt"));
-    try {
-      g.connected_components();
-    } catch (OutOfQueriesException& err) {
-      fails++;
-      if (fails > allow_fail) {
-        printf("More than %i failures failing test\n", allow_fail);
-        throw;
-      }
-    }
-  }
+    g.connected_components();
+  } 
 }
 
 TEST_P(GraphTest, TestCorrectnessOfReheating) {
   write_configuration(GetParam());
-  int num_trials = 10;
-  int allow_fail = 2; // allow 2 failures
-  int fails = 0;
+  int num_trials = 5;
   while (num_trials--) {
     generate_stream({1024,0.002,0.5,0,"./sample.txt","./cumul_sample.txt"});
     std::ifstream in{"./sample.txt"};
@@ -154,16 +132,7 @@ TEST_P(GraphTest, TestCorrectnessOfReheating) {
     g->write_binary("./out_temp.txt");
     g->set_verifier(std::make_unique<FileGraphVerifier>("./cumul_sample.txt"));
     std::vector<std::set<node_id_t>> g_res;
-    try {
-      g_res = g->connected_components();
-    } catch (OutOfQueriesException& err) {
-      fails++;
-      continue;
-      if (fails > allow_fail) {
-        printf("More than %i failures failing test\n", allow_fail);
-        throw;
-      }
-    }
+    g_res = g->connected_components();
     printf("number of CC = %lu\n", g_res.size());
     delete g; // delete g to avoid having multiple graphs open at once. Which is illegal.
 
@@ -182,35 +151,95 @@ TEST_P(GraphTest, TestCorrectnessOfReheating) {
   }
 }
 
-TEST(DynamicTests, TestQueryDuringStream) {
-  generate_stream({1024, 0.002, 0.5, 0, "./sample.txt", "./cumul_sample.txt"});
-  std::ifstream in{"./sample.txt"};
-  node_id_t n;
-  edge_id_t m;
-  in >> n >> m;
-  Graph g(n);
-  MatGraphVerifier verify(n);
+TEST_P(GraphTest, MultipleInserters) {
+  write_configuration(GetParam(), false, 4, 2);
+  int num_trials = 5;
+  while(num_trials--) {
+    generate_stream({1024,0.002,0.5,0,"./sample.txt","./cumul_sample.txt"});
+    std::ifstream in{"./sample.txt"};
+    node_id_t n;
+    edge_id_t m;
+    in >> n >> m;
+    Graph g{n};
+    int type, a, b;
+    while (m--) {
+      in >> type >> a >> b;
+      if (type == INSERT) {
+        g.update({{a, b}, INSERT});
+      } else g.update({{a, b}, DELETE});
+    }
 
-  int type;
-  node_id_t a, b;
-  edge_id_t tenth = m / 10;
-  for(int j = 0; j < 9; j++) {
-    for (edge_id_t i = 0; i < tenth; i++) {
+    g.set_verifier(std::make_unique<FileGraphVerifier>("./cumul_sample.txt"));
+    g.connected_components();
+  } 
+}
+
+TEST(GraphTest, TestQueryDuringStream) {
+  write_configuration(false, false);
+  { // test copying to disk
+    generate_stream({1024, 0.002, 0.5, 0, "./sample.txt", "./cumul_sample.txt"});
+    std::ifstream in{"./sample.txt"};
+    node_id_t n;
+    edge_id_t m;
+    in >> n >> m;
+    Graph g(n);
+    MatGraphVerifier verify(n);
+
+    int type;
+    node_id_t a, b;
+    edge_id_t tenth = m / 10;
+    for(int j = 0; j < 9; j++) {
+      for (edge_id_t i = 0; i < tenth; i++) {
+        in >> type >> a >> b;
+        g.update({{a,b}, (UpdateType)type});
+        verify.edge_update(a, b);
+      }
+      verify.reset_cc_state();
+      g.set_verifier(std::make_unique<MatGraphVerifier>(verify));
+      g.connected_components(true);
+    }
+    m -= 9 * tenth;
+    while(m--) {
       in >> type >> a >> b;
       g.update({{a,b}, (UpdateType)type});
       verify.edge_update(a, b);
     }
     verify.reset_cc_state();
     g.set_verifier(std::make_unique<MatGraphVerifier>(verify));
-    g.connected_components(true);
+    g.connected_components();
   }
-  m -= 9 * tenth;
-  while(m--) {
-    in >> type >> a >> b;
-    g.update({{a,b}, (UpdateType)type});
-    verify.edge_update(a, b);
+
+  write_configuration(false, true);
+  { // test copying in memory
+    generate_stream({1024, 0.002, 0.5, 0, "./sample.txt", "./cumul_sample.txt"});
+    std::ifstream in{"./sample.txt"};
+    node_id_t n;
+    edge_id_t m;
+    in >> n >> m;
+    Graph g(n);
+    MatGraphVerifier verify(n);
+
+    int type;
+    node_id_t a, b;
+    edge_id_t tenth = m / 10;
+    for(int j = 0; j < 9; j++) {
+      for (edge_id_t i = 0; i < tenth; i++) {
+        in >> type >> a >> b;
+        g.update({{a,b}, (UpdateType)type});
+        verify.edge_update(a, b);
+      }
+      verify.reset_cc_state();
+      g.set_verifier(std::make_unique<MatGraphVerifier>(verify));
+      g.connected_components(true);
+    }
+    m -= 9 * tenth;
+    while(m--) {
+      in >> type >> a >> b;
+      g.update({{a,b}, (UpdateType)type});
+      verify.edge_update(a, b);
+    }
+    verify.reset_cc_state();
+    g.set_verifier(std::make_unique<MatGraphVerifier>(verify));
+    g.connected_components();
   }
-  verify.reset_cc_state();
-  g.set_verifier(std::make_unique<MatGraphVerifier>(verify));
-  g.connected_components();
 }

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -6,6 +6,15 @@
 
 static const int fail_factor = 100;
 
+bool contains_inclusive(col_hash_t hash, col_hash_t guess) {
+  for (col_hash_t i = 1; i <= guess; i<<=1) {
+    if (!Bucket_Boruvka::contains(hash, i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 TEST(SketchTestSuite, TestExceptions) {
   Sketch::configure(10 * 10, fail_factor);
   SketchUniquePtr sketch1 = makeSketch(rand());
@@ -24,7 +33,7 @@ TEST(SketchTestSuite, TestExceptions) {
     for (unsigned long long j = 0; j < num_guesses;) {
       uint64_t index = 0;
       for (uint64_t k = 0; k < sketch2->n; ++k) {
-        if (vec_idx[k] && Bucket_Boruvka::contains(Bucket_Boruvka::col_index_hash(k, sketch2->seed + i), 2 << j)) {
+        if (vec_idx[k] && contains_inclusive(Bucket_Boruvka::col_index_hash(k, sketch2->seed + i), 1 << j)) {
           if (index == 0) {
             index = k + 1;
           } else {


### PR DESCRIPTION
## Big Changes
- We now can either backup supernodes to disk or in memory based upon a configuration flag set by the user
- Made Boruvka emulation much more parallel by serially computing the DSU changes and tracking the merges that will need to happen. Then in parallel performing the merges. The boruvka emulation now consists of the following three stages performed repeatedly.
  1. Query Active Supernodes (parallel)
  2. Perform DSU updates and identify merging to be done (serial)
  3. Merge the Supernodes (parallel)
- Additionally, changed the backing up of supernodes to only occur when the supernode in question has been selected by the DSU stage for merging during the first round of Boruvka

## Minor Changes
#### Configuration
- Renamed 'path_prefix' in configuration options to 'disk_dir' to make it clear what it does.
- 'disk_dir' is now where both the gutter tree and Supernodes backed up to disk live

#### Connected Components Algorithm
- Made Graph::update inline (maybe minor performance benefit)
- Added ability to reset Supernode idx and Sketch already_queried variables (useful for continuous CC)
- Renamed function that runs the CC algorithm to 'boruvka_emulation'
- Made all CCs route through Graph::connected_components(bool) and made that the only function that calls BufferingSystem::force_flush()

#### Sketching
- Fixed bug in sketching (we need to use 64 bit column hashes as (2^32)^2 = 2^64)
- Changed contains query to use bitwise & rather than modulus as modulus would break on 2^32 nodes (as we would need to check if all 64 bits are 1 and therefore would attempt to mod by 2^65.

#### Testing
- Fixes graph tests to not allow for failures as these failures should not happen whp
- Add a test for queries during the stream that backs up in memory and on disk
- Add a test that uses parallel processing