### PR TITLE
Optimal sketch guess length

### DIFF
--- a/include/l0_sampling/sketch.h
+++ b/include/l0_sampling/sketch.h
@@ -12,8 +12,9 @@
 #include "../util.h"
 #include <gtest/gtest_prod.h>
 
+// max number of non-zeroes in vector is n/2*n/2=n^2/4
+#define guess_gen(x) double_to_ull(log2(x) - 2)
 #define bucket_gen(d) double_to_ull((log2(d)+1))
-#define guess_gen(x) double_to_ull(log2(x)+1)
 
 enum SampleSketchRet {
   GOOD,  // querying this sketch returned a single non-zero value


### PR DESCRIPTION
On a graph with `n` nodes we are currently using `2log(n) + 1` different guess levels. However the maximum amount of non-zero entries in this `n*n` vector is `n/2 * n/2 = n^2/4`

This change therefore sets the number of guess levels to `2log(n) -2`

We observe a 130,000 insertion per second speedup on kron17 and a reduction in space usage of almost 1 GiB