### PR TITLE
General write_binary functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ FetchContent_Declare(
   GutterTree
 
   GIT_REPOSITORY  https://github.com/GraphStreamingProject/GutterTree.git
-  GIT_TAG         main
+  GIT_TAG         cache_gutter_tree
 )
 
 if (BUILD_BENCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ FetchContent_Declare(
   GutterTree
 
   GIT_REPOSITORY  https://github.com/GraphStreamingProject/GutterTree.git
-  GIT_TAG         cache_gutter_tree
+  GIT_TAG         main
 )
 
 if (BUILD_BENCH)

--- a/include/graph.h
+++ b/include/graph.h
@@ -38,7 +38,7 @@ class MultipleGraphsException : public std::exception {
 class Graph {
 protected:
   node_id_t num_nodes;
-  long seed;
+  uint64_t seed;
   bool update_locked = false;
   bool modified = false;
   // a set containing one "representative" from each supernode
@@ -145,7 +145,7 @@ public:
    *                   calling thread.
    * @returns nothing (supernode delta is in delta_loc).
    */
-  static void generate_delta_node(node_id_t node_n, long node_seed, node_id_t src,
+  static void generate_delta_node(node_id_t node_n, uint64_t node_seed, node_id_t src,
                                   const std::vector<size_t> &edges, Supernode *delta_loc);
 
   /**

--- a/include/graph.h
+++ b/include/graph.h
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <atomic>  // REMOVE LATER
 
-#include <buffering_system.h>
+#include <guttering_system.h>
 #include "supernode.h"
 
 #ifdef VERIFY_SAMPLES_F
@@ -48,8 +48,8 @@ protected:
   node_id_t* parent;
   node_id_t get_parent(node_id_t node);
 
-  // Buffering system for batching updates
-  BufferingSystem *bf;
+  // Guttering system for batching updates
+  GutteringSystem *gts;
 
   void backup_to_disk(const std::vector<node_id_t>& ids_to_backup);
   void restore_from_disk(const std::vector<node_id_t>& ids_to_restore);
@@ -101,9 +101,9 @@ public:
     if (update_locked) throw UpdateLockedException();
     Edge &edge = upd.first;
 
-    bf->insert(edge);
+    gts->insert(edge);
     std::swap(edge.first, edge.second);
-    bf->insert(edge);
+    gts->insert(edge);
   }
 
   /**

--- a/include/graph.h
+++ b/include/graph.h
@@ -36,6 +36,7 @@ class MultipleGraphsException : public std::exception {
  * multiple edges, or weights.
  */
 class Graph {
+protected:
   node_id_t num_nodes;
   long seed;
   bool update_locked = false;

--- a/include/graph_worker.h
+++ b/include/graph_worker.h
@@ -2,11 +2,11 @@
 #include <mutex>
 #include <condition_variable>
 #include <thread>
-#include <buffering_system.h>
 
 // forward declarations
 class Graph;
 class Supernode;
+class GutteringSystem;
 
 class GraphWorker {
 public:
@@ -14,11 +14,11 @@ public:
    * start_workers creates the graph workers and sets them to query the
    * given buffering system.
    * @param _graph           the graph to update.
-   * @param _bf              the buffering system to query.
+   * @param _gts             the guttering system to query.
    * @param _supernode_size  the size of a supernode so that we can allocate
    *                         space for a delta_node.
    */
-  static void start_workers(Graph *_graph, BufferingSystem *_bf, long _supernode_size);
+  static void start_workers(Graph *_graph, GutteringSystem *_gts, long _supernode_size);
   static void stop_workers();    // shutdown and delete GraphWorkers
   static void pause_workers();   // pause the GraphWorkers before CC
   static void unpause_workers(); // unpause the GraphWorkers to resume updates
@@ -39,9 +39,9 @@ private:
    * Create a GraphWorker object by setting metadata and spinning up a thread.
    * @param _id     the id of the new GraphWorker.
    * @param _graph  the graph which this GraphWorker will be updating.
-   * @param _bf     the database data will be extracted from.
+   * @param _gts    the database data will be extracted from.
    */
-  GraphWorker(int _id, Graph *_graph, BufferingSystem *_bf);
+  GraphWorker(int _id, Graph *_graph, GutteringSystem *_gts);
   ~GraphWorker();
 
   /**
@@ -57,7 +57,7 @@ private:
   void do_work(); // function which runs the GraphWorker process
   int id;
   Graph *graph;
-  BufferingSystem *bf;
+  GutteringSystem *gts;
   std::thread thr;
   bool thr_paused; // indicates if this individual thread is paused
 

--- a/include/l0_sampling/sketch.h
+++ b/include/l0_sampling/sketch.h
@@ -36,7 +36,7 @@ private:
   static size_t num_guesses;       // Portion of array length, number of guesses
 
   // Seed used for hashing operations in this sketch.
-  const long seed;
+  const uint64_t seed;
   // pointers to buckets
   vec_t*      bucket_a;
   vec_hash_t* bucket_c;
@@ -55,8 +55,8 @@ private:
   char buckets[1];
 
   // private constructors -- use makeSketch
-  Sketch(long seed);
-  Sketch(long seed, std::istream &binary_in);
+  Sketch(uint64_t seed);
+  Sketch(uint64_t seed, std::istream &binary_in);
   Sketch(const Sketch& s);
 
 public:
@@ -68,8 +68,8 @@ public:
    * @param binary_in  (Optional) A file which holds an encoding of a sketch
    * @return           A pointer to a newly constructed sketch 
    */
-  static Sketch* makeSketch(void* loc, long seed);
-  static Sketch* makeSketch(void* loc, long seed, std::istream &binary_in);
+  static Sketch* makeSketch(void* loc, uint64_t seed);
+  static Sketch* makeSketch(void* loc, uint64_t seed, std::istream &binary_in);
   
   /**
    * Copy constructor to create a sketch from another

--- a/include/l0_sampling/sketch.h
+++ b/include/l0_sampling/sketch.h
@@ -56,7 +56,7 @@ private:
 
   // private constructors -- use makeSketch
   Sketch(long seed);
-  Sketch(long seed, std::fstream &binary_in);
+  Sketch(long seed, std::istream &binary_in);
   Sketch(const Sketch& s);
 
 public:
@@ -69,7 +69,7 @@ public:
    * @return           A pointer to a newly constructed sketch 
    */
   static Sketch* makeSketch(void* loc, long seed);
-  static Sketch* makeSketch(void* loc, long seed, std::fstream &binary_in);
+  static Sketch* makeSketch(void* loc, long seed, std::istream &binary_in);
   
   /**
    * Copy constructor to create a sketch from another
@@ -135,7 +135,7 @@ public:
    * Serialize the sketch to a binary output stream.
    * @param out the stream to write to.
    */
-  void write_binary(std::fstream& binary_out);
+  void write_binary(std::ostream& binary_out);
 };
 
 class MultipleQueryException : public std::exception {

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -26,7 +26,7 @@ class Supernode {
 
 public:
   const uint64_t n; // for creating a copy
-  const long seed; // for creating a copy
+  const uint64_t seed; // for creating a copy
   
 private:
   size_t sketch_size;
@@ -40,14 +40,14 @@ private:
    * @param n     the total number of nodes in the graph.
    * @param seed  the (fixed) seed value passed to each supernode.
    */
-  Supernode(uint64_t n, long seed);
+  Supernode(uint64_t n, uint64_t seed);
 
   /**
    * @param n         the total number of nodes in the graph.
    * @param seed      the (fixed) seed value passed to each supernode.
    * @param binary_in A stream to read the data from.
    */
-  Supernode(uint64_t n, long seed, std::istream &binary_in);
+  Supernode(uint64_t n, uint64_t seed, std::istream &binary_in);
 
   // get the ith sketch in the sketch array
   inline Sketch* get_sketch(size_t i) {
@@ -61,8 +61,8 @@ private:
 
   Supernode(const Supernode& s);
 public:
-  static Supernode* makeSupernode(uint64_t n, long seed);
-  static Supernode* makeSupernode(uint64_t n, long seed, std::istream &binary_in);
+  static Supernode* makeSupernode(uint64_t n, uint64_t seed);
+  static Supernode* makeSupernode(uint64_t n, uint64_t seed, std::istream &binary_in);
 
   /**
    * Makes a supernode at the provided location (and does no error checking).
@@ -71,7 +71,7 @@ public:
    * @param seed    the (fixed) seed value passed to each supernode.
    * @return        a pointer to loc, the location of the supernode.
    */
-  static Supernode* makeSupernode(void* loc, uint64_t n, long seed);
+  static Supernode* makeSupernode(void* loc, uint64_t n, uint64_t seed);
   static Supernode* makeSupernode(const Supernode& s);
 
   ~Supernode();
@@ -128,7 +128,7 @@ public:
    * @param updates the batch of updates to apply.
    * @param loc     the location to place the delta in
    */
-  static void delta_supernode(uint64_t n, long seed, const
+  static void delta_supernode(uint64_t n, uint64_t seed, const
   std::vector<vec_t>& updates, void *loc);
 
   /**

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -45,9 +45,9 @@ private:
   /**
    * @param n         the total number of nodes in the graph.
    * @param seed      the (fixed) seed value passed to each supernode.
-   * @param binary_in A stream to read the file from.
+   * @param binary_in A stream to read the data from.
    */
-  Supernode(uint64_t n, long seed, std::fstream &binary_in);
+  Supernode(uint64_t n, long seed, std::istream &binary_in);
 
   // get the ith sketch in the sketch array
   inline Sketch* get_sketch(size_t i) {
@@ -62,7 +62,7 @@ private:
   Supernode(const Supernode& s);
 public:
   static Supernode* makeSupernode(uint64_t n, long seed);
-  static Supernode* makeSupernode(uint64_t n, long seed, std::fstream &binary_in);
+  static Supernode* makeSupernode(uint64_t n, long seed, std::istream &binary_in);
 
   /**
    * Makes a supernode at the provided location (and does no error checking).
@@ -135,7 +135,7 @@ public:
    * Serialize the supernode to a binary output stream.
    * @param out the stream to write to.
    */
-  void write_binary(std::fstream &binary_out);
+  void write_binary(std::ostream &binary_out);
 
   // return the number of sketches held in this supernode
   int get_num_sktch() { return num_sketches; };

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -39,11 +39,11 @@ Graph::Graph(node_id_t num_nodes): num_nodes(num_nodes) {
   backup_file = disk_loc + "supernode_backup.data";
   // Create the buffering system and start the graphWorkers
   if (std::get<0>(conf))
-    bf = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
+    gts = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
-    bf = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
+    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
 
-  GraphWorker::start_workers(this, bf, Supernode::get_size());
+  GraphWorker::start_workers(this, gts, Supernode::get_size());
   open_graph = true;
 }
 
@@ -76,11 +76,11 @@ Graph::Graph(const std::string& input_file) : num_updates(0) {
   backup_file = disk_loc + "supernode_backup.data";
   // Create the buffering system and start the graphWorkers
   if (std::get<0>(conf))
-    bf = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
+    gts = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
-    bf = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
+    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
 
-  GraphWorker::start_workers(this, bf, Supernode::get_size());
+  GraphWorker::start_workers(this, gts, Supernode::get_size());
   open_graph = true;
 }
 
@@ -91,7 +91,7 @@ Graph::~Graph() {
   delete[] parent;
   delete representatives;
   GraphWorker::stop_workers(); // join the worker threads
-  delete bf;
+  delete gts;
   open_graph = false;
 }
 
@@ -325,7 +325,7 @@ void Graph::restore_from_disk(const std::vector<node_id_t>& ids_to_restore) {
 
 std::vector<std::set<node_id_t>> Graph::connected_components(bool cont) {
   flush_start = std::chrono::steady_clock::now();
-  bf->force_flush(); // flush everything in buffering system to make final updates
+  gts->force_flush(); // flush everything in guttering system to make final updates
   GraphWorker::pause_workers(); // wait for the workers to finish applying the updates
   flush_end = std::chrono::steady_clock::now();
   // after this point all updates have been processed from the buffer tree
@@ -365,7 +365,7 @@ node_id_t Graph::get_parent(node_id_t node) {
 }
 
 void Graph::write_binary(const std::string& filename) {
-  bf->force_flush(); // flush everything in buffering system to make final updates
+  gts->force_flush(); // flush everything in buffering system to make final updates
   GraphWorker::pause_workers(); // wait for the workers to finish applying the updates
   // after this point all updates have been processed from the buffering system
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -95,7 +95,7 @@ Graph::~Graph() {
   open_graph = false;
 }
 
-void Graph::generate_delta_node(node_id_t node_n, long node_seed, node_id_t
+void Graph::generate_delta_node(node_id_t node_n, uint64_t node_seed, node_id_t
                src, const std::vector<size_t> &edges, Supernode *delta_loc) {
   std::vector<vec_t> updates;
   updates.reserve(edges.size());

--- a/src/l0_sampling/sketch.cpp
+++ b/src/l0_sampling/sketch.cpp
@@ -17,7 +17,7 @@ Sketch* Sketch::makeSketch(void* loc, long seed) {
   return new (loc) Sketch(seed);
 }
 
-Sketch* Sketch::makeSketch(void* loc, long seed, std::fstream &binary_in) {
+Sketch* Sketch::makeSketch(void* loc, long seed, std::istream &binary_in) {
   return new (loc) Sketch(seed, binary_in);
 }
 
@@ -37,7 +37,7 @@ Sketch::Sketch(long seed): seed(seed) {
   }
 }
 
-Sketch::Sketch(long seed, std::fstream &binary_in): seed(seed) {
+Sketch::Sketch(long seed, std::istream &binary_in): seed(seed) {
   // establish the bucket_a and bucket_c locations
   bucket_a = reinterpret_cast<vec_t*>(buckets);
   bucket_c = reinterpret_cast<vec_hash_t*>(buckets + num_elems * sizeof(vec_t));
@@ -146,7 +146,7 @@ std::ostream& operator<< (std::ostream &os, const Sketch &sketch) {
   return os;
 }
 
-void Sketch::write_binary(std::fstream& binary_out) {
+void Sketch::write_binary(std::ostream& binary_out) {
   binary_out.write((char*)bucket_a, num_elems * sizeof(vec_t));
   binary_out.write((char*)bucket_c, num_elems * sizeof(vec_hash_t));
 }

--- a/src/l0_sampling/sketch.cpp
+++ b/src/l0_sampling/sketch.cpp
@@ -13,11 +13,11 @@ size_t Sketch::num_guesses;
  * Static functions for creating sketches with a provided memory location.
  * We use these in the production system to keep supernodes virtually contiguous.
  */
-Sketch* Sketch::makeSketch(void* loc, long seed) {
+Sketch* Sketch::makeSketch(void* loc, uint64_t seed) {
   return new (loc) Sketch(seed);
 }
 
-Sketch* Sketch::makeSketch(void* loc, long seed, std::istream &binary_in) {
+Sketch* Sketch::makeSketch(void* loc, uint64_t seed, std::istream &binary_in) {
   return new (loc) Sketch(seed, binary_in);
 }
 
@@ -25,7 +25,7 @@ Sketch* Sketch::makeSketch(void* loc, const Sketch& s) {
   return new (loc) Sketch(s);
 }
 
-Sketch::Sketch(long seed): seed(seed) {
+Sketch::Sketch(uint64_t seed): seed(seed) {
   // establish the bucket_a and bucket_c locations
   bucket_a = reinterpret_cast<vec_t*>(buckets);
   bucket_c = reinterpret_cast<vec_hash_t*>(buckets + num_elems * sizeof(vec_t));
@@ -37,7 +37,7 @@ Sketch::Sketch(long seed): seed(seed) {
   }
 }
 
-Sketch::Sketch(long seed, std::istream &binary_in): seed(seed) {
+Sketch::Sketch(uint64_t seed, std::istream &binary_in): seed(seed) {
   // establish the bucket_a and bucket_c locations
   bucket_a = reinterpret_cast<vec_t*>(buckets);
   bucket_c = reinterpret_cast<vec_hash_t*>(buckets + num_elems * sizeof(vec_t));

--- a/src/supernode.cpp
+++ b/src/supernode.cpp
@@ -16,7 +16,7 @@ Supernode::Supernode(uint64_t n, long seed): idx(0), num_sketches(log2(n)/(log2(
   }
 }
 
-Supernode::Supernode(uint64_t n, long seed, std::fstream &binary_in) :
+Supernode::Supernode(uint64_t n, long seed, std::istream &binary_in) :
   idx(0), num_sketches(log2(n)/(log2(3)-1)), n(n), seed(seed), sketch_size(Sketch::sketchSizeof()) {
 
   uint32_t sketch_width = guess_gen(Sketch::get_failure_factor());
@@ -39,7 +39,7 @@ Supernode* Supernode::makeSupernode(uint64_t n, long seed) {
   return new (loc) Supernode(n, seed);
 }
 
-Supernode* Supernode::makeSupernode(uint64_t n, long seed, std::fstream &binary_in) {
+Supernode* Supernode::makeSupernode(uint64_t n, long seed, std::istream &binary_in) {
   void *loc = malloc(bytes_size);
   return new (loc) Supernode(n, seed, binary_in);
 }
@@ -115,7 +115,7 @@ void Supernode::delta_supernode(uint64_t n, long seed,
   }
 }
 
-void Supernode::write_binary(std::fstream& binary_out) {
+void Supernode::write_binary(std::ostream& binary_out) {
   for (int i = 0; i < num_sketches; ++i) {
     get_sketch(i)->write_binary(binary_out);
   }

--- a/src/supernode.cpp
+++ b/src/supernode.cpp
@@ -5,7 +5,7 @@
 
 uint32_t Supernode::bytes_size;
 
-Supernode::Supernode(uint64_t n, long seed): idx(0), num_sketches(log2(n)/(log2(3)-1)),
+Supernode::Supernode(uint64_t n, uint64_t seed): idx(0), num_sketches(log2(n)/(log2(3)-1)),
                n(n), seed(seed), sketch_size(Sketch::sketchSizeof()) {
 
   uint32_t sketch_width = guess_gen(Sketch::get_failure_factor());
@@ -16,7 +16,7 @@ Supernode::Supernode(uint64_t n, long seed): idx(0), num_sketches(log2(n)/(log2(
   }
 }
 
-Supernode::Supernode(uint64_t n, long seed, std::istream &binary_in) :
+Supernode::Supernode(uint64_t n, uint64_t seed, std::istream &binary_in) :
   idx(0), num_sketches(log2(n)/(log2(3)-1)), n(n), seed(seed), sketch_size(Sketch::sketchSizeof()) {
 
   uint32_t sketch_width = guess_gen(Sketch::get_failure_factor());
@@ -34,17 +34,17 @@ Supernode::Supernode(const Supernode& s) : idx(s.idx), num_sketches(s.num_sketch
   }
 }
 
-Supernode* Supernode::makeSupernode(uint64_t n, long seed) {
+Supernode* Supernode::makeSupernode(uint64_t n, uint64_t seed) {
   void *loc = malloc(bytes_size);
   return new (loc) Supernode(n, seed);
 }
 
-Supernode* Supernode::makeSupernode(uint64_t n, long seed, std::istream &binary_in) {
+Supernode* Supernode::makeSupernode(uint64_t n, uint64_t seed, std::istream &binary_in) {
   void *loc = malloc(bytes_size);
   return new (loc) Supernode(n, seed, binary_in);
 }
 
-Supernode* Supernode::makeSupernode(void* loc, uint64_t n, long seed) {
+Supernode* Supernode::makeSupernode(void* loc, uint64_t n, uint64_t seed) {
   return new (loc) Supernode(n, seed);
 }
 
@@ -106,7 +106,7 @@ void Supernode::apply_delta_update(const Supernode* delta_node) {
  * Considered using spin-threads and parallelism within sketch::update, but
  * this was slow (at least on small graph inputs).
  */
-void Supernode::delta_supernode(uint64_t n, long seed,
+void Supernode::delta_supernode(uint64_t n, uint64_t seed,
                const std::vector<vec_t> &updates, void *loc) {
   auto delta_node = makeSupernode(loc, n, seed);
 #pragma omp parallel for num_threads(GraphWorker::get_group_size()) default(shared)


### PR DESCRIPTION
Use std::ostream and std::istream to allow for general purpose writing of supernodes and sketches to binary either in a file or in memory.