### PR TITLE
feat: expose sketch specifics from supernode class

### DIFF
--- a/include/graph.h
+++ b/include/graph.h
@@ -60,7 +60,8 @@ protected:
    * @param query  an array of supernode query results
    * @param reps   an array containing node indices for the representative of each supernode
    */
-  void sample_supernodes(std::pair<Edge, SampleSketchRet> *query, std::vector<node_id_t> &reps);
+  virtual void sample_supernodes(std::pair<Edge, SampleSketchRet> *query,
+                          std::vector<node_id_t> &reps);
 
   /**
    * @param copy_supernodes  an array to be filled with supernodes

--- a/include/l0_sampling/sketch.h
+++ b/include/l0_sampling/sketch.h
@@ -119,7 +119,7 @@ public:
    */
   std::pair<vec_t, SampleSketchRet> query();
 
-  inline uint64_t get_seed() {
+  inline uint64_t get_seed() const {
     return seed;
   }
 
@@ -140,6 +140,7 @@ public:
    * @param out the stream to write to.
    */
   void write_binary(std::ostream& binary_out);
+  void write_binary(std::ostream& binary_out) const;
 };
 
 class MultipleQueryException : public std::exception {

--- a/include/l0_sampling/sketch.h
+++ b/include/l0_sampling/sketch.h
@@ -119,6 +119,10 @@ public:
    */
   std::pair<vec_t, SampleSketchRet> query();
 
+  inline uint64_t get_seed() {
+    return seed;
+  }
+
   /**
    * Operator to add a sketch to another one in-place. Guaranteed to be
    * thread-safe for the sketch being added to. It is up to the user to

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -51,6 +51,13 @@ private:
   Supernode(uint64_t n, uint64_t seed, std::istream &binary_in);
 
   Supernode(const Supernode& s);
+
+
+  // get the ith sketch in the sketch array
+  inline Sketch* get_sketch(size_t i) {
+    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
+  }
+  
 public:
   /**
    * Supernode construtors
@@ -85,9 +92,8 @@ public:
   // return the number of sketches held in this supernode
   int get_num_sktch() { return num_sketches; };
 
-    // get the ith sketch in the sketch array
-  inline Sketch* get_sketch(size_t i) {
-    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
+  inline bool out_of_queries() {
+    return idx == num_sketches;
   }
 
   // get the ith sketch in the sketch array

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -50,16 +50,6 @@ private:
    */
   Supernode(uint64_t n, uint64_t seed, std::istream &binary_in);
 
-  // get the ith sketch in the sketch array
-  inline Sketch* get_sketch(size_t i) {
-    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
-  }
-
-  // get the ith sketch in the sketch array
-  inline const Sketch* get_sketch(size_t i) const {
-    return reinterpret_cast<const Sketch*>(sketch_buffer + i * sketch_size);
-  }
-
   Supernode(const Supernode& s);
 public:
   /**
@@ -84,8 +74,25 @@ public:
     bytes_size = sizeof(Supernode) + log2(n)/(log2(3)-1) * Sketch::sketchSizeof() - sizeof(char);
   }
 
-  static inline uint32_t get_size() {
+  static inline size_t get_size() {
     return bytes_size;
+  }
+
+  inline size_t get_sketch_size() {
+    return sketch_size;
+  }
+
+  // return the number of sketches held in this supernode
+  int get_num_sktch() { return num_sketches; };
+
+    // get the ith sketch in the sketch array
+  inline Sketch* get_sketch(size_t i) {
+    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
+  }
+
+  // get the ith sketch in the sketch array
+  inline const Sketch* get_sketch(size_t i) const {
+    return reinterpret_cast<const Sketch*>(sketch_buffer + i * sketch_size);
   }
 
   // reset the supernode query metadata
@@ -139,9 +146,6 @@ public:
    * @param out the stream to write to.
    */
   void write_binary(std::ostream &binary_out);
-
-  // return the number of sketches held in this supernode
-  int get_num_sktch() { return num_sketches; };
 };
 
 

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -52,6 +52,16 @@ private:
 
   Supernode(const Supernode& s);
 
+  // get the ith sketch in the sketch array
+  inline Sketch* get_sketch(size_t i) {
+    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
+  }
+
+  // version of above for const supernode objects
+  inline const Sketch* get_sketch(size_t i) const {
+    return reinterpret_cast<const Sketch*>(sketch_buffer + i * sketch_size);
+  }
+
 public:
   /**
    * Supernode construtors
@@ -94,19 +104,8 @@ public:
     return idx;
   }
 
-
   inline void incr_idx() {
     ++idx;
-  }
-
-  // get the ith sketch in the sketch array
-  inline Sketch* get_sketch(size_t i) {
-    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
-  }
-
-  // version of above for const supernode objects
-  inline const Sketch* get_sketch(size_t i) const {
-    return reinterpret_cast<const Sketch*>(sketch_buffer + i * sketch_size);
   }
 
   // reset the supernode query metadata
@@ -116,6 +115,11 @@ public:
       get_sketch(i)->reset_queried();
     }
     idx = 0;
+  }
+
+  // get the ith sketch in the sketch array as a const object
+  inline const Sketch* get_const_sketch(size_t i) {
+    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
   }
 
   /**

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -95,6 +95,10 @@ public:
   }
 
 
+  inline void incr_idx() {
+    ++idx;
+  }
+
   // get the ith sketch in the sketch array
   inline Sketch* get_sketch(size_t i) {
     return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -52,12 +52,6 @@ private:
 
   Supernode(const Supernode& s);
 
-
-  // get the ith sketch in the sketch array
-  inline Sketch* get_sketch(size_t i) {
-    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
-  }
-  
 public:
   /**
    * Supernode construtors
@@ -96,7 +90,17 @@ public:
     return idx == num_sketches;
   }
 
+  inline int curr_idx() {
+    return idx;
+  }
+
+
   // get the ith sketch in the sketch array
+  inline Sketch* get_sketch(size_t i) {
+    return reinterpret_cast<Sketch*>(sketch_buffer + i * sketch_size);
+  }
+
+  // version of above for const supernode objects
   inline const Sketch* get_sketch(size_t i) const {
     return reinterpret_cast<const Sketch*>(sketch_buffer + i * sketch_size);
   }

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -23,8 +23,7 @@ Graph::Graph(node_id_t num_nodes): num_nodes(num_nodes) {
   supernodes = new Supernode*[num_nodes];
   parent = new node_id_t[num_nodes];
   size = new node_id_t[num_nodes];
-  seed = 69420;
-//  seed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  seed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
   std::mt19937_64 r(seed);
   seed = r();
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -23,7 +23,8 @@ Graph::Graph(node_id_t num_nodes): num_nodes(num_nodes) {
   supernodes = new Supernode*[num_nodes];
   parent = new node_id_t[num_nodes];
   size = new node_id_t[num_nodes];
-  seed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  seed = 69420;
+//  seed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
   std::mt19937_64 r(seed);
   seed = r();
 

--- a/src/l0_sampling/sketch.cpp
+++ b/src/l0_sampling/sketch.cpp
@@ -147,6 +147,10 @@ std::ostream& operator<< (std::ostream &os, const Sketch &sketch) {
 }
 
 void Sketch::write_binary(std::ostream& binary_out) {
+  const_cast<const Sketch*>(this)->write_binary(binary_out);
+}
+
+void Sketch::write_binary(std::ostream &binary_out) const {
   binary_out.write((char*)bucket_a, num_elems * sizeof(vec_t));
   binary_out.write((char*)bucket_c, num_elems * sizeof(vec_hash_t));
 }


### PR DESCRIPTION
Distributing sketch queries needs to be able to get sketches from within a supernode. Right now, the necessary functions are private.