### PR TITLE
number of inserters pass through + virtual destructor

### DIFF
--- a/include/graph.h
+++ b/include/graph.h
@@ -96,8 +96,8 @@ protected:
 
   static bool open_graph;
 public:
-  explicit Graph(node_id_t num_nodes, int ninserters=1);
-  explicit Graph(const std::string &input_file, int ninserters=1);
+  explicit Graph(node_id_t num_nodes, int num_inserters=1);
+  explicit Graph(const std::string &input_file, int num_inserters=1);
 
   virtual ~Graph();
 

--- a/include/graph.h
+++ b/include/graph.h
@@ -96,10 +96,10 @@ protected:
 
   static bool open_graph;
 public:
-  explicit Graph(node_id_t num_nodes);
-  explicit Graph(const std::string &input_file);
+  explicit Graph(node_id_t num_nodes, int ninserters=1);
+  explicit Graph(const std::string &input_file, int ninserters=1);
 
-  ~Graph();
+  virtual ~Graph();
 
   inline void update(GraphUpdate upd, int thr_id = 0) {
     if (update_locked) throw UpdateLockedException();

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -12,7 +12,7 @@
 // static variable for enforcing that only one graph is open at a time
 bool Graph::open_graph = false;
 
-Graph::Graph(node_id_t num_nodes, int ninserters): num_nodes(num_nodes) {
+Graph::Graph(node_id_t num_nodes, int num_inserters): num_nodes(num_nodes) {
   if (open_graph) throw MultipleGraphsException();
 
 #ifdef VERIFY_SAMPLES_F
@@ -43,13 +43,13 @@ Graph::Graph(node_id_t num_nodes, int ninserters): num_nodes(num_nodes) {
   if (std::get<0>(conf))
     gts = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
-    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups(), ninserters);
+    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups(), num_inserters);
 
   GraphWorker::start_workers(this, gts, Supernode::get_size());
   open_graph = true;
 }
 
-Graph::Graph(const std::string& input_file, int ninserters) : num_updates(0) {
+Graph::Graph(const std::string& input_file, int num_inserters) : num_updates(0) {
   if (open_graph) throw MultipleGraphsException();
   
   vec_t sketch_fail_factor;
@@ -82,7 +82,7 @@ Graph::Graph(const std::string& input_file, int ninserters) : num_updates(0) {
   if (std::get<0>(conf))
     gts = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
-    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups(), ninserters);
+    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups(), num_inserters);
 
   GraphWorker::start_workers(this, gts, Supernode::get_size());
   open_graph = true;

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -12,7 +12,7 @@
 // static variable for enforcing that only one graph is open at a time
 bool Graph::open_graph = false;
 
-Graph::Graph(node_id_t num_nodes): num_nodes(num_nodes) {
+Graph::Graph(node_id_t num_nodes, int ninserters): num_nodes(num_nodes) {
   if (open_graph) throw MultipleGraphsException();
 
 #ifdef VERIFY_SAMPLES_F
@@ -43,13 +43,13 @@ Graph::Graph(node_id_t num_nodes): num_nodes(num_nodes) {
   if (std::get<0>(conf))
     gts = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
-    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
+    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups(), ninserters);
 
   GraphWorker::start_workers(this, gts, Supernode::get_size());
   open_graph = true;
 }
 
-Graph::Graph(const std::string& input_file) : num_updates(0) {
+Graph::Graph(const std::string& input_file, int ninserters) : num_updates(0) {
   if (open_graph) throw MultipleGraphsException();
   
   vec_t sketch_fail_factor;
@@ -82,7 +82,7 @@ Graph::Graph(const std::string& input_file) : num_updates(0) {
   if (std::get<0>(conf))
     gts = new GutterTree(disk_loc, num_nodes, GraphWorker::get_num_groups(), true);
   else
-    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups());
+    gts = new StandAloneGutters(num_nodes, GraphWorker::get_num_groups(), ninserters);
 
   GraphWorker::start_workers(this, gts, Supernode::get_size());
   open_graph = true;


### PR DESCRIPTION
To initialize memory, we need to know the number of threads (and therefore number of buffers to the buffers).

This passes through that value.

Also, we were inheriting from a non-virtual destructor. This is undefined behavior.

When merging this, we should revert the change in the Distributed repo that points cmake to this branch.