### PR TITLE
feat: clearer pairing fn names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if (BUILD_EXE)
 
   # executables for experiment/benchmarking
   add_executable(efficient_gen
+    src/util.cpp
     test/util/efficient_gen/edge_gen.cpp
     test/util/efficient_gen/efficient_gen.cpp)
   target_link_libraries(efficient_gen PRIVATE xxhash GraphZeppelinCommon)

--- a/include/test/efficient_gen.h
+++ b/include/test/efficient_gen.h
@@ -1,9 +1,9 @@
 #pragma once
 
-void write_edges(uint32_t n, double p, std::string out_f);
+void write_edges(uint32_t n, double p, const std::string& out_f);
 // insert, delete based on a geometric distribution with ratio p
 // i.e. p% of edges will be deleted, p^2% will be re-inserted, p^3 will be re-deleted
 // until 1 element is left
-void insert_delete(double p, std::string in_file, std::string out_file);
+void insert_delete(double p, const std::string& in_file, const std::string& out_file);
 
 void write_cumul(const std::string& stream_f, const std::string& cumul_f);

--- a/include/util.h
+++ b/include/util.h
@@ -9,7 +9,10 @@
 unsigned long long int double_to_ull(double d, double epsilon = 0.00000001);
 
 /**
- * Concatenates two node ids to form an edge ids
+ * A function N x N -> N that implements a non-self-edge pairing function
+ * that does not respect order of inputs.
+ * That is, (2,2) would not be a valid input. (1,3) and (3,1) would be treated as
+ * identical inputs.
  * @return i + j*(j-1)/2
  */
 uint64_t nondirectional_non_self_edge_pairing_fn(uint32_t i, uint32_t j);
@@ -20,6 +23,19 @@ uint64_t nondirectional_non_self_edge_pairing_fn(uint32_t i, uint32_t j);
  * @return the pair, with left and right ordered lexicographically.
  */
 std::pair<uint32_t , uint32_t> inv_nondir_non_self_edge_pairing_fn(uint64_t idx);
+
+/**
+ * Concatenates two node ids to form an edge ids
+ * @return (i << 32) & j
+ */
+uint64_t concat_pairing_fn(uint32_t i, uint32_t j);
+
+/**
+ * Inverts the concat pairing function.
+ * @param idx
+ * @return the pair, with left and right ordered lexicographically.
+ */
+std::pair<uint32_t , uint32_t> inv_concat_pairing_fn(uint64_t idx);
 
 /**
  * Configures the system using the configuration file streaming.conf

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -123,10 +123,10 @@ void Graph::generate_delta_node(node_id_t node_n, uint64_t node_seed, node_id_t
   for (const auto& edge : edges) {
     if (src < edge) {
       updates.push_back(static_cast<vec_t>(
-                            nondirectional_non_self_edge_pairing_fn(src, edge)));
+                              concat_pairing_fn(src, edge)));
     } else {
       updates.push_back(static_cast<vec_t>(
-                            nondirectional_non_self_edge_pairing_fn(edge, src)));
+                              concat_pairing_fn(edge, src)));
     }
   }
   Supernode::delta_supernode(node_n, node_seed, updates, delta_loc);

--- a/src/supernode.cpp
+++ b/src/supernode.cpp
@@ -55,7 +55,7 @@ std::pair<Edge, SampleSketchRet> Supernode::sample() {
   std::pair<vec_t, SampleSketchRet> query_ret = get_sketch(idx++)->query();
   vec_t idx = query_ret.first;
   SampleSketchRet ret_code = query_ret.second;
-  return {inv_nondir_non_self_edge_pairing_fn(idx), ret_code};
+  return {inv_concat_pairing_fn(idx), ret_code};
 }
 
 void Supernode::merge(Supernode &other) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,7 +1,8 @@
-#include <stdexcept>
+//#include <stdexcept>
+#include <limits>
+#include <cmath>
+#include <graph_zeppelin_common.h>
 #include "../include/util.h"
-#include "../include/graph_worker.h"
-#include "../include/graph.h"
 
 typedef uint32_t ul;
 typedef uint64_t ull;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -13,7 +13,34 @@ unsigned long long int double_to_ull(double d, double epsilon) {
   return (unsigned long long) (d + epsilon);
 }
 
-ull nondirectional_non_self_edge_pairing_fn(ul i, ul j) {
+uint64_t nondirectional_non_self_edge_pairing_fn(uint32_t i, uint32_t j) {
+  // swap i,j if necessary
+  if (i > j) {
+    std::swap(i,j);
+  }
+  ull jm = j-1ull;
+  if ((j & 1ull) == 0ull) j>>=1ull;
+  else jm>>=1ull;
+//  if (ULLMAX/j < jm)
+//    throw std::overflow_error("Computation would overflow unsigned long long max");
+  j*=jm;
+//  if (ULLMAX-j < i)
+//    throw std::overflow_error("Computation would overflow unsigned long long max");
+  return i+j;
+}
+
+std::pair<uint32_t , uint32_t> inv_nondir_non_self_edge_pairing_fn(uint64_t idx) {
+  // we ignore possible overflow
+  ull eidx = 8ull*idx + 1ull;
+  eidx = sqrt(eidx)+1ull;
+  eidx/=2ull;
+  ull i,j = (ull) eidx;
+  if ((j & 1ull) == 0ull) i = idx-(j>>1ull)*(j-1ull);
+  else i = idx-j*((j-1ull)>>1ull);
+  return {i, j};
+}
+
+ull concat_pairing_fn(ul i, ul j) {
   // swap i,j if necessary
   if (i > j) {
     std::swap(i,j);
@@ -21,7 +48,7 @@ ull nondirectional_non_self_edge_pairing_fn(ul i, ul j) {
   return ((ull)i << num_bits) | j;
 }
 
-std::pair<ul, ul> inv_nondir_non_self_edge_pairing_fn(ull idx) {
+std::pair<ul, ul> inv_concat_pairing_fn(ull idx) {
   ul j = idx & 0xFFFFFFFF;
   ul i = idx >> num_bits;
   return {i, j};

--- a/test/supernode_test.cpp
+++ b/test/supernode_test.cpp
@@ -69,8 +69,8 @@ TEST_F(SupernodeTestSuite, TestSampleInsertGrinder) {
 
   // insert all edges
   for (auto edge : *graph_edges) {
-    vec_t encoded = nondirectional_non_self_edge_pairing_fn(edge.first, edge
-    .second);
+    vec_t encoded = concat_pairing_fn(edge.first, edge
+          .second);
     snodes[edge.first]->update(encoded);
     snodes[edge.second]->update(encoded);
   }
@@ -112,15 +112,15 @@ TEST_F(SupernodeTestSuite, TestSampleDeleteGrinder) {
 
   // insert all edges
   for (auto edge : *graph_edges) {
-    vec_t encoded = nondirectional_non_self_edge_pairing_fn(edge.first, edge
-    .second);
+    vec_t encoded = concat_pairing_fn(edge.first, edge
+          .second);
     snodes[edge.first]->update(encoded);
     snodes[edge.second]->update(encoded);
   }
   // then remove half of them (odds)
   for (auto edge : *odd_graph_edges) {
-    vec_t encoded = nondirectional_non_self_edge_pairing_fn(edge.first, edge
-    .second);
+    vec_t encoded = concat_pairing_fn(edge.first, edge
+          .second);
     snodes[edge.first]->update(encoded);
     snodes[edge.second]->update(encoded);
   }
@@ -242,7 +242,7 @@ TEST_F(SupernodeTestSuite, TestSerialization) {
 
   // insert all edges
   for (auto edge : *graph_edges) {
-    vec_t encoded = nondirectional_non_self_edge_pairing_fn(edge.first, edge
+    vec_t encoded = concat_pairing_fn(edge.first, edge
           .second);
     snodes[edge.first]->update(encoded);
     snodes[edge.second]->update(encoded);

--- a/test/util/efficient_gen/edge_gen.cpp
+++ b/test/util/efficient_gen/edge_gen.cpp
@@ -12,7 +12,7 @@ typedef uint64_t ull;
 const ull ULLMAX = std::numeric_limits<ull>::max();
 const uint8_t num_bits = sizeof(node_id_t) * 8;
 
-ull nondirectional_non_self_edge_pairing_fn(ul i, ul j) {
+ull concat_pairing_fn(ul i, ul j) {
   // swap i,j if necessary
   if (i > j) {
     std::swap(i,j);
@@ -20,7 +20,7 @@ ull nondirectional_non_self_edge_pairing_fn(ul i, ul j) {
   return ((ull)i << num_bits) | j;
 }
 
-std::pair<ul, ul> inv_nondir_non_self_edge_pairing_fn(ull idx) {
+std::pair<ul, ul> inv_concat_pairing_fn(ull idx) {
   ul j = idx & 0xFFFFFFFF;
   ul i = idx >> num_bits;
   return {i, j};
@@ -39,7 +39,7 @@ void write_edges(ul n, double p, std::string out_f) {
   std::cout << "Generating possible edges" << std::endl;
   for (unsigned i=0; i < n; ++i) {
     for (unsigned j=i+1;j < n; ++j) {
-      arr[idx++] = nondirectional_non_self_edge_pairing_fn(i, j);
+      arr[idx++] = concat_pairing_fn(i, j);
     }
   }
 
@@ -51,7 +51,7 @@ void write_edges(ul n, double p, std::string out_f) {
 
   std::cout << "Writing edges to file" << std::endl;
   while (m--) {
-    out << inv_nondir_non_self_edge_pairing_fn(arr[m]) << std::endl;
+    out << inv_concat_pairing_fn(arr[m]) << std::endl;
   }
 
   out.close();
@@ -81,7 +81,7 @@ void insert_delete(double p, std::string in_file, std::string out_file) {
   for (unsigned i=0;i<ins_del_arr[1];++i) {
     in >> a >> b;
     out << "0 " << a << " " << b << std::endl;
-    memoized[i] = nondirectional_non_self_edge_pairing_fn(a, b);
+    memoized[i] = concat_pairing_fn(a, b);
   }
 
   for (unsigned i=ins_del_arr[1];i<m;++i) {
@@ -93,7 +93,7 @@ void insert_delete(double p, std::string in_file, std::string out_file) {
     int temp = i%2;
     for (unsigned j=0;j<ins_del_arr[i];++j) {
       out << temp << " ";
-      out << inv_nondir_non_self_edge_pairing_fn(memoized[j]) << std::endl;
+      out << inv_concat_pairing_fn(memoized[j]) << std::endl;
     }
   }
   free(memoized);

--- a/test/util/efficient_gen/edge_gen.cpp
+++ b/test/util/efficient_gen/edge_gen.cpp
@@ -1,37 +1,22 @@
 #include <fstream>
 #include <algorithm>
 #include <cmath>
+#include <random>
 #include <vector>
 #include <iostream>
 #include "../../../include/test/efficient_gen.h"
 #include "../../../include/types.h"
+#include "../../../include/util.h"
 
 typedef uint32_t ul;
 typedef uint64_t ull;
-
-const ull ULLMAX = std::numeric_limits<ull>::max();
-const uint8_t num_bits = sizeof(node_id_t) * 8;
-
-ull concat_pairing_fn(ul i, ul j) {
-  // swap i,j if necessary
-  if (i > j) {
-    std::swap(i,j);
-  }
-  return ((ull)i << num_bits) | j;
-}
-
-std::pair<ul, ul> inv_concat_pairing_fn(ull idx) {
-  ul j = idx & 0xFFFFFFFF;
-  ul i = idx >> num_bits;
-  return {i, j};
-}
 
 std::ofstream& operator<< (std::ofstream &os, const std::pair<ull,ull> p) {
   os << p.first << " " << p.second;
   return os;
 }
 
-void write_edges(ul n, double p, std::string out_f) {
+void write_edges(ul n, double p, const std::string& out_f) {
   ull num_edges = ((ull)n*(n-1))/2;
   ull* arr = (ull*) malloc(num_edges*sizeof(ull));
   ul idx = 0;
@@ -44,7 +29,7 @@ void write_edges(ul n, double p, std::string out_f) {
   }
 
   std::cout << "Permuting edges" << std::endl;  
-  std::random_shuffle(arr,arr+num_edges);
+  std::shuffle(arr,arr+num_edges, std::mt19937(std::random_device()()));
   std::ofstream out(out_f);
   ull m = (ull) (num_edges*p);
   out << n << " " << m << std::endl;
@@ -58,7 +43,7 @@ void write_edges(ul n, double p, std::string out_f) {
   free(arr);
 }
 
-void insert_delete(double p, std::string in_file, std::string out_file) {
+void insert_delete(double p, const std::string& in_file, const std::string& out_file) {
   std::cout << "Deleting and reinserting some edges" << std::endl;
   std::ifstream in(in_file);
   std::ofstream out(out_file);

--- a/test/util/graph_gen.cpp
+++ b/test/util/graph_gen.cpp
@@ -24,7 +24,7 @@ void write_edges(long n, double p, const std::string& out_f) {
   ul e = 0;
   for (unsigned i = 0; i < n; ++i) {
     for (unsigned j = i+1; j < n; ++j) {
-      arr[e++] = nondirectional_non_self_edge_pairing_fn(i,j);
+      arr[e++] = concat_pairing_fn(i, j);
     }
   }
   std::shuffle(arr,arr+num_edges, std::mt19937(std::random_device()()));
@@ -33,7 +33,7 @@ void write_edges(long n, double p, const std::string& out_f) {
   out << n << " " << m << endl;
 
   while (m--) {
-    out << inv_nondir_non_self_edge_pairing_fn(arr[m]) << endl;
+    out << inv_concat_pairing_fn(arr[m]) << endl;
   }
   out.flush();
   out.close();
@@ -69,7 +69,7 @@ void insert_delete(double p, int max_appearances, const std::string& in_file,
   for (unsigned i=0;i<ins_del_arr[1];++i) {
     in >> a >> b;
     out << "0 " << a << " " << b << endl;
-    memoized[i] = nondirectional_non_self_edge_pairing_fn(a, b);
+    memoized[i] = concat_pairing_fn(a, b);
   }
 
   for (unsigned i=ins_del_arr[1];i<m;++i) {
@@ -89,7 +89,7 @@ void insert_delete(double p, int max_appearances, const std::string& in_file,
     int temp = i % 2;
     for (unsigned j = 0; j < ins_del_arr[i]; ++j) {
       out << temp << " ";
-      out << inv_nondir_non_self_edge_pairing_fn(memoized[j]) << endl;
+      out << inv_concat_pairing_fn(memoized[j]) << endl;
     }
   }
   out.flush();

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -7,8 +7,8 @@ TEST(UtilTestSuite, TestNonDirectionalNonSEPairingFn) {
     for (int j = 0; j < 1000; ++j) {
       if (i==j) continue;
       exp = {std::min(i,j),std::max(i,j)};
-      ASSERT_EQ(exp, inv_nondir_non_self_edge_pairing_fn
-      (nondirectional_non_self_edge_pairing_fn(i,j)));
+      ASSERT_EQ(exp, inv_concat_pairing_fn
+            (concat_pairing_fn(i, j)));
     }
   }
 }

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include "../include/util.h"
 
-TEST(UtilTestSuite, TestNonDirectionalNonSEPairingFn) {
+TEST(UtilTestSuite, TestConcatPairingFn) {
   std::pair<uint32_t,uint32_t> exp;
   for (int i = 0; i < 1000; ++i) {
     for (int j = 0; j < 1000; ++j) {


### PR DESCRIPTION
the current pairing function we use is not the non-self-edge pairing function we had used before. However, the original pairing function is still useful in some applications. This PR renames the current pairing function and restores the old pairing function