### PR TITLE
Remove static alloc and cleanup warnings

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04]
+        os: [ubuntu-latest, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/include/graph.h
+++ b/include/graph.h
@@ -151,7 +151,7 @@ public:
       }
     }
 #else
-    dsu_valid = false;
+    if (dsu_valid) dsu_valid = false;
 #endif // USE_EAGER_DSU
   }
 

--- a/include/graph.h
+++ b/include/graph.h
@@ -151,7 +151,7 @@ public:
       }
     }
 #else
-    if (dsu_valid) dsu_valid = false;
+    unlikely_if(dsu_valid) dsu_valid = false;
 #endif // USE_EAGER_DSU
   }
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -154,8 +154,8 @@ inline void Graph::sample_supernodes(std::pair<Edge, SampleSketchRet> *query,
   if (except) std::rethrow_exception(err);
 }
 
-inline std::vector<std::vector<node_id_t>> Graph::supernodes_to_merge(std::pair<Edge, SampleSketchRet>
-               *query, std::vector<node_id_t> &reps) {
+inline std::vector<std::vector<node_id_t>> Graph::supernodes_to_merge(
+    std::pair<Edge, SampleSketchRet> *query, std::vector<node_id_t> &reps) {
   std::vector<std::vector<node_id_t>> to_merge(num_nodes);
   std::vector<node_id_t> new_reps;
   for (auto i : reps) {
@@ -254,7 +254,7 @@ std::vector<std::set<node_id_t>> Graph::boruvka_emulation(bool make_copy) {
   Supernode** copy_supernodes;
   if (make_copy && config._backup_in_mem) 
     copy_supernodes = new Supernode*[num_nodes];
-  std::pair<Edge, SampleSketchRet> query[num_nodes];
+  std::pair<Edge, SampleSketchRet> *query = new std::pair<Edge, SampleSketchRet>[num_nodes];
   std::vector<node_id_t> reps(num_nodes);
   std::vector<node_id_t> backed_up;
   std::fill(size, size + num_nodes, 1);
@@ -304,9 +304,11 @@ std::vector<std::set<node_id_t>> Graph::boruvka_emulation(bool make_copy) {
     } while (modified);
   } catch (...) {
     cleanup_copy();
+    delete[] query;
     std::rethrow_exception(std::current_exception());
   }
   cleanup_copy();
+  delete[] query;
   dsu_valid = true;
 
   auto retval = cc_from_dsu();

--- a/src/l0_sampling/sketch.cpp
+++ b/src/l0_sampling/sketch.cpp
@@ -116,6 +116,8 @@ std::pair<vec_t, SampleSketchRet> Sketch::query() {
 }
 
 std::pair<std::vector<vec_t>, SampleSketchRet> Sketch::exhaustive_query() {
+  unlikely_if (already_queried)
+    throw MultipleQueryException();
   std::vector<vec_t> ret;
 
   unlikely_if (bucket_a[num_elems - 1] == 0 && bucket_c[num_elems - 1] == 0)
@@ -136,8 +138,6 @@ std::pair<std::vector<vec_t>, SampleSketchRet> Sketch::exhaustive_query() {
       }
     }
   }
-  unlikely_if (already_queried)
-    throw MultipleQueryException();
   already_queried = true;
 
   unlikely_if (ret.size() == 0)

--- a/test/supernode_test.cpp
+++ b/test/supernode_test.cpp
@@ -286,23 +286,25 @@ TEST_F(SupernodeTestSuite, ExhaustiveSample) {
       }
     }
 
-    std::pair<std::vector<Edge>, SampleSketchRet> query_ret = s_node->exhaustive_sample();
-    if (query_ret.second != GOOD) {
-      ASSERT_EQ(query_ret.first.size(), 0);
+    // do 4 samples
+    for (size_t i = 0; i < 4; i++) {
+      std::pair<std::vector<Edge>, SampleSketchRet> query_ret = s_node->exhaustive_sample();
+      if (query_ret.second != GOOD) {
+        ASSERT_EQ(query_ret.first.size(), 0);
+      }
+
+      // assert everything returned is valid
+      for (Edge e : query_ret.first) {
+        ASSERT_GT(e.src, 0);
+        ASSERT_LE(e.src, 10);
+        ASSERT_GT(e.dst, e.src);
+        ASSERT_LE(e.dst, 10);
+      }
+
+      // assert everything returned is unique
+      std::set<Edge> unique_elms(query_ret.first.begin(), query_ret.first.end());
+      ASSERT_EQ(unique_elms.size(), query_ret.first.size());
     }
-
-    // assert everything returned is valid
-    for (Edge e : query_ret.first) {
-      ASSERT_GT(e.src, 0);
-      ASSERT_LE(e.src, 10);
-      ASSERT_GT(e.dst, e.src);
-      ASSERT_LE(e.dst, 10);
-    }
-
-    // assert everything returned is unique
-    std::set<Edge> unique_elms(query_ret.first.begin(), query_ret.first.end());
-    ASSERT_EQ(unique_elms.size(), query_ret.first.size());
-
     free(s_node);
   }
 }

--- a/test/util/graph_verifier_test.cpp
+++ b/test/util/graph_verifier_test.cpp
@@ -12,8 +12,8 @@ TEST(DeterministicToolsTestSuite, TestKruskal) {
 TEST(DeterministicToolsTestSuite, TestEdgeVerifier) {
   FileGraphVerifier verifier(1024, curr_dir+"/../res/multiples_graph_1024.txt");
   // add edges of the form {i,2i}
-  for (int i = 2; i < 512; ++i) {
-    verifier.verify_edge({i,i*2});
+  for (node_id_t i = 2; i < 512; ++i) {
+    verifier.verify_edge({i, i*2});
   }
   // throw on nonexistent edge
   ASSERT_THROW(verifier.verify_edge({69,420}), BadEdgeException);
@@ -33,8 +33,8 @@ TEST(DeterministicToolsTestSuite, TestCCVerifier) {
   verifier.verify_cc(1);
   verifier.verify_cc(911);
   // add edges of the form {i,2i}
-  for (int i = 2; i < 512; ++i) {
-    verifier.verify_edge({i,i*2});
+  for (node_id_t i = 2; i < 512; ++i) {
+    verifier.verify_edge({i, i*2});
   }
   // nothing else is currently a CC
   for (int i = 2; i < 512; ++i) {

--- a/tools/statistical_testing/graph_testing.cpp
+++ b/tools/statistical_testing/graph_testing.cpp
@@ -11,7 +11,8 @@ static inline int do_run() {
     edge_id_t m;
     in >> n >> m;
     Graph g{n};
-    int type, a, b;
+    int type;
+    node_id_t a, b;
     while (m--) {
       in >> type >> a >> b;
       if (type == INSERT) {


### PR DESCRIPTION
Remove static allocation in boruvka_emulation and fix some compiler warnings.
(Also update GitHub workflow to remove deprecated ubuntu-18.04)