### PR TITLE
Verifier changes

### DIFF
--- a/include/test/file_graph_verifier.h
+++ b/include/test/file_graph_verifier.h
@@ -11,14 +11,11 @@
  */
 class FileGraphVerifier : public GraphVerifier {
   std::vector<std::set<node_id_t>> kruskal_ref;
-  std::vector<std::set<node_id_t>> boruvka_cc;
-  DisjointSetUnion<node_id_t> sets;
 
 public:
   FileGraphVerifier(node_id_t n, const std::string& input_file);
 
   void verify_edge(Edge edge);
-  void verify_cc(node_id_t node);
   void verify_soln(std::vector<std::set<node_id_t>>& retval);
 
   /**

--- a/include/test/graph_verifier.h
+++ b/include/test/graph_verifier.h
@@ -13,21 +13,11 @@ protected:
 
 public:
   /**
-   * Verifies an edge exists in the graph. Verifies that the edge is in the cut
-   * of both the endpoints of the edge.
+   * Verifies an edge exists in the graph.
    * @param edge the edge to be tested.
-   * @param det_graph the adjacency list representation of the graph in question.
-   * @throws BadEdgeException if the edge does not satisfy both conditions.
+   * @throws BadEdgeException if the edge does not exist in the graph.
    */
   virtual void verify_edge(Edge edge) = 0;
-
-  /**
-   * Verifies the supernode of the given node is a (maximal) connected component.
-   * That is, there are no edges in its cut.
-   * @param node the node to be tested.
-   * @throws NotCCException   if the supernode is not a connected component.
-   */
-  virtual void verify_cc(node_id_t node) = 0;
 
   /**
    * Verifies the connected components solution is correct. Compares
@@ -35,7 +25,7 @@ public:
    */
   virtual void verify_soln(std::vector<std::set<node_id_t>> &retval) = 0;
 
-  std::vector<std::vector<bool>> extract_adj_matrix() {return adj_matrix;}
+  std::vector<std::vector<bool>> extract_adj_matrix() { return adj_matrix; }
 
   GraphVerifier() = default;
   GraphVerifier(std::vector<std::vector<bool>> _adj) : adj_matrix(std::move(_adj)) {};
@@ -46,12 +36,6 @@ public:
 class BadEdgeException : public std::exception {
   virtual const char* what() const throw() {
     return "The edge is not in the cut of the sample!";
-  }
-};
-
-class NotCCException : public std::exception {
-  virtual const char* what() const throw() {
-    return "The supernode is not a connected component. It has edges in its cut!";
   }
 };
 

--- a/include/test/mat_graph_verifier.h
+++ b/include/test/mat_graph_verifier.h
@@ -11,10 +11,7 @@
  */
 class MatGraphVerifier : public GraphVerifier {
   std::vector<std::set<node_id_t>> kruskal_ref;
-  std::vector<std::set<node_id_t>> boruvka_cc;
-
   node_id_t n;
-  DisjointSetUnion<node_id_t> sets;
 
   /**
    * Runs Kruskal's (deterministic) CC algo.
@@ -27,12 +24,11 @@ public:
 
   // When we want to build a MatGraphVerifier without iterative edge_updates
   MatGraphVerifier(node_id_t n, std::vector<std::vector<bool>> _adj)
-   : GraphVerifier(_adj), n(n), sets(n) { reset_cc_state(); };
+   : GraphVerifier(_adj), n(n) { reset_cc_state(); };
   
   void reset_cc_state();       // run this function before using as a verifier in CC
   void edge_update(node_id_t src, node_id_t dst);
 
   void verify_edge(Edge edge);
-  void verify_cc(node_id_t node);
   void verify_soln(std::vector<std::set<node_id_t>> &retval);
 };

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -169,12 +169,8 @@ inline std::vector<std::vector<node_id_t>> Graph::supernodes_to_merge(
       new_reps.push_back(i);
       continue;
     }
-    if (ret_code == ZERO) {
-#ifdef VERIFY_SAMPLES_F
-      verifier->verify_cc(i);
-#endif
+    if (ret_code == ZERO)
       continue;
-    }
 
     // query dsu
     node_id_t a = get_parent(edge.src);

--- a/test/util/file_graph_verifier.cpp
+++ b/test/util/file_graph_verifier.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <cassert>
 
-FileGraphVerifier::FileGraphVerifier(node_id_t n, const std::string &input_file) : sets(n) {
+FileGraphVerifier::FileGraphVerifier(node_id_t n, const std::string &input_file) {
   std::ifstream in(input_file);
   if (!in) {
     throw std::invalid_argument("FileGraphVerifier: Could not open: " + input_file);
@@ -19,7 +19,6 @@ FileGraphVerifier::FileGraphVerifier(node_id_t n, const std::string &input_file)
   if (num_nodes != n) throw std::invalid_argument("num_nodes != n in FileGraphVerifier");
 
   for (unsigned i = 0; i < n; ++i) {
-    boruvka_cc.push_back({i});
     adj_matrix.emplace_back(n - i);
   }
   while (m--) {
@@ -63,23 +62,6 @@ void FileGraphVerifier::verify_edge(Edge edge) {
     printf("Got an error on edge (%u, %u): edge is not in graph!\n", edge.src, edge.dst);
     throw BadEdgeException();
   }
-
-  DSUMergeRet<node_id_t> ret = sets.merge(edge.src, edge.dst);
-  if (!ret.merged) {
-    printf("Got an error of node (%u, %u): components already joined!\n", edge.src, edge.dst);
-    throw BadEdgeException();
-  }
-
-  // if all checks pass, merge supernodes
-  for (auto& i : boruvka_cc[ret.child]) boruvka_cc[ret.root].insert(i);
-}
-
-void FileGraphVerifier::verify_cc(node_id_t node) {
-  node = sets.find_root(node);
-  for (const auto& cc : kruskal_ref) {
-    if (boruvka_cc[node] == cc) return;
-  }
-  throw NotCCException();
 }
 
 void FileGraphVerifier::verify_soln(std::vector<std::set<node_id_t>> &retval) {

--- a/test/util/graph_verifier_test.cpp
+++ b/test/util/graph_verifier_test.cpp
@@ -18,26 +18,13 @@ TEST(DeterministicToolsTestSuite, TestEdgeVerifier) {
   // throw on nonexistent edge
   ASSERT_THROW(verifier.verify_edge({69,420}), BadEdgeException);
   ASSERT_THROW(verifier.verify_edge({420,69}), BadEdgeException);
-  // throw on already-included edge
-  ASSERT_THROW(verifier.verify_edge({120,240}), BadEdgeException);
-  ASSERT_THROW(verifier.verify_edge({240,120}), BadEdgeException);
-  // throw on edge within the same set
-  ASSERT_THROW(verifier.verify_edge({250,1000}), BadEdgeException);
-  ASSERT_THROW(verifier.verify_edge({1000,250}), BadEdgeException);
 }
 
 TEST(DeterministicToolsTestSuite, TestCCVerifier) {
   FileGraphVerifier verifier (1024, curr_dir+"/../res/multiples_graph_1024.txt");
   // {0}, {1}, and primes \in [521,1021] are CCs
-  verifier.verify_cc(0);
-  verifier.verify_cc(1);
-  verifier.verify_cc(911);
   // add edges of the form {i,2i}
   for (node_id_t i = 2; i < 512; ++i) {
     verifier.verify_edge({i, i*2});
-  }
-  // nothing else is currently a CC
-  for (int i = 2; i < 512; ++i) {
-    ASSERT_THROW(verifier.verify_cc(i), NotCCException);
   }
 }

--- a/test/util/mat_graph_verifier.cpp
+++ b/test/util/mat_graph_verifier.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <cassert>
 
-MatGraphVerifier::MatGraphVerifier(node_id_t n) : n(n), sets(n) {
+MatGraphVerifier::MatGraphVerifier(node_id_t n) : n(n) {
   adj_matrix = std::vector<std::vector<bool>>(n);
   for (node_id_t i = 0; i < n; ++i)
     adj_matrix[i] = std::vector<bool>(n - i);
@@ -23,10 +23,6 @@ void MatGraphVerifier::edge_update(node_id_t src, node_id_t dst) {
 
 void MatGraphVerifier::reset_cc_state() {
   kruskal_ref = kruskal();
-  sets.reset();
-  boruvka_cc.clear();
-  for (node_id_t i = 0; i < n; ++i)
-    boruvka_cc.push_back({i});
 }
 
 std::vector<std::set<node_id_t>> MatGraphVerifier::kruskal() {
@@ -58,23 +54,6 @@ void MatGraphVerifier::verify_edge(Edge edge) {
     printf("Got an error on edge (%u, %u): edge is not in adj_matrix\n", edge.src, edge.dst);
     throw BadEdgeException();
   }
-
-  DSUMergeRet<node_id_t> ret = sets.merge(edge.src, edge.dst); // perform the merge
-  if (!ret.merged) {
-    printf("Got an error on edge (%u, %u): components already joined!\n", edge.src, edge.dst);
-    throw BadEdgeException();
-  }
-
-  // if all checks pass, update boruvka_cc by merging in set elements of child
-  for (auto& i : boruvka_cc[ret.child]) boruvka_cc[ret.root].insert(i);
-}
-
-void MatGraphVerifier::verify_cc(node_id_t node) {
-  node = sets.find_root(node);
-  for (const auto& cc : kruskal_ref) {
-    if (boruvka_cc[node] == cc) return;
-  }
-  throw NotCCException();
 }
 
 void MatGraphVerifier::verify_soln(std::vector<std::set<node_id_t>> &retval) {


### PR DESCRIPTION
The verifier is a little overpowered and as a consequence there are a bunch of race conditions if edges are verified by multiple threads. This pull request reduces the power of the verifier while ensuring it still catches bugs. The verifier now checks the following:
 - Edge correctness, each edge found in queries is validated as being within the graph
 - CC correctness, the connected components returned by the query are verified to be correct.

The verifiers no longer check that no redundant edges are passed to `verify_edge` this means the verifier has to run a dsu which is a little overpowered and introduces race conditions. We already have tests for the DSU so it's probably fine.
