### PR TITLE
Bug fix for Multithreaded DSU

### DIFF
--- a/include/dsu.h
+++ b/include/dsu.h
@@ -25,11 +25,15 @@ class DisjointSetUnion {
   // if sum odd, larger first
   inline void order_edge(T& a, T& b) {
     if (size[a] < size[b]) std::swap(a, b);
-    if (size[a] == size[b]) {
-      if ((a + b) % 2 == 0 && a > b)
-        std::swap(a, b);
-      else if ((a + b) % 2 == 1 && a < b)
-        std::swap(a, b);
+    else if (size[a] == size[b]) {
+      if ((a + b) % 2 == 0) {
+        a = std::min(a, b);
+        b = std::max(a, b);
+      }
+      else {
+        a = std::max(a, b);
+        b = std::min(a, b);
+      }
     }
   }
 
@@ -111,11 +115,15 @@ class DisjointSetUnion_MT {
   // if sum odd, larger first
   inline void order_edge(T& a, T& b) {
     if (size[a] < size[b]) std::swap(a, b);
-    if (size[a] == size[b]) {
-      if ((a + b) % 2 == 0 && a > b)
-        std::swap(a, b);
-      else if ((a + b) % 2 == 1 && a < b)
-        std::swap(a, b);
+    else if (size[a] == size[b]) {
+      if ((a + b) % 2 == 0) {
+        a = std::min(a, b);
+        b = std::max(a, b);
+      }
+      else {
+        a = std::max(a, b);
+        b = std::min(a, b);
+      }
     }
   }
 

--- a/include/dsu.h
+++ b/include/dsu.h
@@ -24,15 +24,13 @@ class DisjointSetUnion {
   // if sum even, smaller first
   // if sum odd, larger first
   inline void order_edge(T& a, T& b) {
-    if (size[a] < size[b]) std::swap(a, b);
+    if (size[a] < size[b])
+      std::swap(a, b);
     else if (size[a] == size[b]) {
-      if ((a + b) % 2 == 0) {
-        a = std::min(a, b);
-        b = std::max(a, b);
-      }
-      else {
-        a = std::max(a, b);
-        b = std::min(a, b);
+      if ((a + b) % 2 == 0 && a > b) {
+        std::swap(a, b);
+      } else if ((a + b) % 2 == 1 && a < b) {
+        std::swap(a, b);
       }
     }
   }
@@ -114,15 +112,13 @@ class DisjointSetUnion_MT {
   // if sum even, smaller first
   // if sum odd, larger first
   inline void order_edge(T& a, T& b) {
-    if (size[a] < size[b]) std::swap(a, b);
+    if (size[a] < size[b])
+      std::swap(a, b);
     else if (size[a] == size[b]) {
-      if ((a + b) % 2 == 0) {
-        a = std::min(a, b);
-        b = std::max(a, b);
-      }
-      else {
-        a = std::max(a, b);
-        b = std::min(a, b);
+      if ((a + b) % 2 == 0 && a > b) {
+        std::swap(a, b);
+      } else if ((a + b) % 2 == 1 && a < b) {
+        std::swap(a, b);
       }
     }
   }


### PR DESCRIPTION
This pull request fixes an edge case bug in the multithreaded DSU. Specifically the error occurs under the following conditions.

1. Two threads find the same edge and attempt to perform a DSU merge
2. The endpoints of the edge (x, y) have the same component size, i.e. size[x] == size[y]
3. By chance, thread 1 makes y the parent of x and simultaneously thread 2 makes x the parent of y.

This will not cause the CAS to fail because thread 1 is operating on parent[x] while thread 2 is operating upon parent[y]. To solve this issue we make the ordering of edges deterministic and fixed. Thus, both threads orient the edge the same way if the sizes are identical. To "randomize" the roots, we switch whether the smaller or larger of x/y is first based upon if their sum is even/odd.