### PR TITLE
Support for allocating more sketches than normal

### DIFF
--- a/include/graph_configuration.h
+++ b/include/graph_configuration.h
@@ -30,6 +30,12 @@ private:
   // How many OMP threads each graph worker uses
   size_t _group_size = 1;
 
+  // Option to create more sketches than for standard connected components
+  // Ex factor of 1, double the sketches
+  //    factor of 0.5, 1.5 times the sketches
+  //    factor of 0, normal quantity of sketches
+  double _adtl_skts_factor = 0;
+
   // Configuration for the guttering system
   GutteringConfiguration _gutter_conf;
 
@@ -48,6 +54,8 @@ public:
   GraphConfiguration& num_groups(size_t num_groups);
 
   GraphConfiguration& group_size(size_t group_size);
+
+  GraphConfiguration& adtl_skts_factor(double factor);
 
   GutteringConfiguration& gutter_conf();
 

--- a/include/graph_configuration.h
+++ b/include/graph_configuration.h
@@ -31,10 +31,9 @@ private:
   size_t _group_size = 1;
 
   // Option to create more sketches than for standard connected components
-  // Ex factor of 1, double the sketches
-  //    factor of 0.5, 1.5 times the sketches
-  //    factor of 0, normal quantity of sketches
-  double _adtl_skts_factor = 0;
+  // Ex factor of 1.5, 1.5 times the sketches
+  //    factor of 1, normal quantity of sketches
+  double _adtl_skts_factor = 1;
 
   // Configuration for the guttering system
   GutteringConfiguration _gutter_conf;

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -88,9 +88,10 @@ public:
 
   ~Supernode();
 
-  static inline void configure(uint64_t n, vec_t sketch_fail_factor=default_fail_factor) {
-    Sketch::configure(n*n, sketch_fail_factor);
-    max_sketches = log2(n)/(log2(3)-1);
+  static inline void configure(uint64_t n, vec_t sketch_fail_factor = default_fail_factor,
+                               double skt_factor = 0) {
+    Sketch::configure(n * n, sketch_fail_factor);
+    max_sketches = log2(n) / (log2(3) - 1) * (skt_factor + 1);
     bytes_size = sizeof(Supernode) + max_sketches * Sketch::sketchSizeof();
     serialized_size = max_sketches * Sketch::serialized_size();
   }

--- a/include/supernode.h
+++ b/include/supernode.h
@@ -89,9 +89,9 @@ public:
   ~Supernode();
 
   static inline void configure(uint64_t n, vec_t sketch_fail_factor = default_fail_factor,
-                               double skt_factor = 0) {
+                               double skt_factor = 1) {
     Sketch::configure(n * n, sketch_fail_factor);
-    max_sketches = log2(n) / (log2(3) - 1) * (skt_factor + 1);
+    max_sketches = log2(n) / (log2(3) - 1) * skt_factor;
     bytes_size = sizeof(Supernode) + max_sketches * Sketch::sketchSizeof();
     serialized_size = max_sketches * Sketch::serialized_size();
   }

--- a/src/graph_configuration.cpp
+++ b/src/graph_configuration.cpp
@@ -39,15 +39,15 @@ GraphConfiguration& GraphConfiguration::group_size(size_t group_size) {
 
 GraphConfiguration& GraphConfiguration::adtl_skts_factor(double factor) {
   _adtl_skts_factor = factor;
-  if (_adtl_skts_factor < 0) {
-    std::cout << "adtl_skts_factor=" << _adtl_skts_factor << " is out of bounds. [0, infty)"
-              << "Defaulting to 0." << std::endl;
-    _adtl_skts_factor = 0;
+  if (_adtl_skts_factor <= 1) {
+    std::cout << "adtl_skts_factor=" << _adtl_skts_factor << " is out of bounds. [1, infty)"
+              << "Defaulting to 1." << std::endl;
+    _adtl_skts_factor = 1;
   }
-  if (_adtl_skts_factor > 0) {
+  if (_adtl_skts_factor > 1) {
     std::cerr << "WARNING: Your graph configuration specifies using a factor " << _adtl_skts_factor 
               << " more memory than normal." << std::endl;
-    std::cerr << "         Is this intentional? If not, set adtl_skts_factor to zero" << std::endl;
+    std::cerr << "         Is this intentional? If not, set adtl_skts_factor to one" << std::endl;
   }
   return *this;
 }

--- a/src/graph_configuration.cpp
+++ b/src/graph_configuration.cpp
@@ -20,7 +20,7 @@ GraphConfiguration& GraphConfiguration::backup_in_mem(bool backup_in_mem) {
 GraphConfiguration& GraphConfiguration::num_groups(size_t num_groups) {
   _num_groups = num_groups;
   if (_num_groups < 1) {
-    std::cout << "num_groups="<< _num_groups << " is out of bounds. "
+    std::cout << "num_groups="<< _num_groups << " is out of bounds. [1, infty)"
               << "Defaulting to 1." << std::endl;
     _num_groups = 1;
   }
@@ -30,9 +30,24 @@ GraphConfiguration& GraphConfiguration::num_groups(size_t num_groups) {
 GraphConfiguration& GraphConfiguration::group_size(size_t group_size) {
   _group_size = group_size;
   if (_group_size < 1) {
-    std::cout << "group_size="<< _group_size << " is out of bounds. "
+    std::cout << "group_size="<< _group_size << " is out of bounds. [1, infty)"
               << "Defaulting to 1." << std::endl;
     _group_size = 1;
+  }
+  return *this;
+}
+
+GraphConfiguration& GraphConfiguration::adtl_skts_factor(double factor) {
+  _adtl_skts_factor = factor;
+  if (_adtl_skts_factor < 0) {
+    std::cout << "adtl_skts_factor=" << _adtl_skts_factor << " is out of bounds. [0, infty)"
+              << "Defaulting to 0." << std::endl;
+    _adtl_skts_factor = 0;
+  }
+  if (_adtl_skts_factor > 0) {
+    std::cerr << "WARNING: Your graph configuration specifies using a factor " << _adtl_skts_factor 
+              << " more memory than normal." << std::endl;
+    std::cerr << "         Is this intentional? If not, set adtl_skts_factor to zero" << std::endl;
   }
   return *this;
 }

--- a/tools/process_stream.cpp
+++ b/tools/process_stream.cpp
@@ -1,8 +1,15 @@
 #include <graph.h>
 #include <binary_graph_stream.h>
 #include <thread>
+#include <sys/resource.h> // for rusage
 
 static bool shutdown = false;
+
+static double get_max_mem_used() {
+  struct rusage data;
+  getrusage(RUSAGE_SELF, &data);
+  return (double) data.ru_maxrss / 1024.0;
+}
 
 /*
  * Function which is run in a seperate thread and will query
@@ -12,7 +19,7 @@ static bool shutdown = false;
  * @param start_time  the time that we started stream ingestion
  */
 void track_insertions(uint64_t total, Graph *g, std::chrono::steady_clock::time_point start_time) {
-  total = total * 2;                // we insert 2 edge updates per edge
+  total = total * 2; // we insert 2 edge updates per edge
 
   printf("Insertions\n");
   printf("Progress:                    | 0%%\r"); fflush(stdout);
@@ -71,7 +78,7 @@ int main(int argc, char **argv) {
   std::cout << "num_updates = " << num_updates << std::endl;
   std::cout << std::endl;
 
-  auto config = GraphConfiguration().gutter_sys(STANDALONE).num_groups(num_threads);
+  auto config = GraphConfiguration().gutter_sys(STANDALONE).num_groups(num_threads).adtl_skts_factor(0.5);
   config.gutter_conf().gutter_factor(-4);
   Graph g{num_nodes, config, reader_threads};
 
@@ -117,4 +124,5 @@ int main(int argc, char **argv) {
   std::cout << "  Flush Gutters(sec):           " << flush_time.count() << std::endl;
   std::cout << "  Boruvka's Algorithm(sec):     " << cc_alg_time.count() << std::endl;
   std::cout << "Connected Components:         " << CC_num << std::endl;
+  std::cout << "Maximum Memory Usage:         " << get_max_mem_used() << std::endl;
 }

--- a/tools/process_stream.cpp
+++ b/tools/process_stream.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
   std::cout << "num_updates = " << num_updates << std::endl;
   std::cout << std::endl;
 
-  auto config = GraphConfiguration().gutter_sys(STANDALONE).num_groups(num_threads).adtl_skts_factor(0.5);
+  auto config = GraphConfiguration().gutter_sys(STANDALONE).num_groups(num_threads);
   config.gutter_conf().gutter_factor(-4);
   Graph g{num_nodes, config, reader_threads};
 
@@ -124,5 +124,5 @@ int main(int argc, char **argv) {
   std::cout << "  Flush Gutters(sec):           " << flush_time.count() << std::endl;
   std::cout << "  Boruvka's Algorithm(sec):     " << cc_alg_time.count() << std::endl;
   std::cout << "Connected Components:         " << CC_num << std::endl;
-  std::cout << "Maximum Memory Usage:         " << get_max_mem_used() << std::endl;
+  std::cout << "Maximum Memory Usage(MiB):    " << get_max_mem_used() << std::endl;
 }


### PR DESCRIPTION
We need to, for a variety of potential applications, be able to allocate more than just O(log n) sketches. This pull request gives that option to users through the `graph_configuration`.