### PR TITLE
Added functions to perform a decomposed update

### DIFF
--- a/include/sketch.h
+++ b/include/sketch.h
@@ -155,9 +155,11 @@ class Sketch {
     sample_idx = 0;
   }
 
+  #ifndef L0_SAMPLING
   vec_hash_t get_checksum(const vec_t update_idx);
   std::vector<size_t> const get_bucket_ids(const vec_t update_idx);
   void update_buckets(const vec_t update_idx, const vec_hash_t checksum, const std::vector<size_t>& bucket_ids);
+  #endif
   
   // return the size of the sketching datastructure in bytes (just the buckets, not the metadata)
   inline size_t bucket_array_bytes() const { return num_buckets * sizeof(Bucket); }

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -155,6 +155,10 @@ class Sketch {
     sample_idx = 0;
   }
 
+  vec_hash_t get_checksum(const vec_t update_idx);
+  std::vector<size_t> const get_bucket_ids(const vec_t update_idx);
+  void update_buckets(const vec_t update_idx, const vec_hash_t checksum, const std::vector<size_t>& bucket_ids);
+  
   // return the size of the sketching datastructure in bytes (just the buckets, not the metadata)
   inline size_t bucket_array_bytes() const { return num_buckets * sizeof(Bucket); }
 

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -33,6 +33,12 @@ struct ExhaustiveSketchSample {
   SampleResult result;
 };
 
+struct SketchDelta {
+  vec_t update_idx;
+  vec_hash_t checksum;
+  std::vector<size_t> bucket_ids;
+};
+
 /**
  * Sketch for graph processing, either CubeSketch or CameoSketch.
  * Sub-linear representation of a vector.
@@ -155,11 +161,8 @@ class Sketch {
     sample_idx = 0;
   }
 
-  #ifndef L0_SAMPLING
-  vec_hash_t get_checksum(const vec_t update_idx);
-  std::vector<size_t> const get_bucket_ids(const vec_t update_idx);
-  void update_buckets(const vec_t update_idx, const vec_hash_t checksum, const std::vector<size_t>& bucket_ids);
-  #endif
+  SketchDelta const get_delta(const vec_t update_idx);
+  void apply_delta(const SketchDelta delta);
   
   // return the size of the sketching datastructure in bytes (just the buckets, not the metadata)
   inline size_t bucket_array_bytes() const { return num_buckets * sizeof(Bucket); }

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -83,6 +83,7 @@ void Sketch::update(const vec_t update_idx) {
 }
 #endif
 
+#ifndef L0_SAMPLING
 vec_hash_t Sketch::get_checksum(const vec_t update_idx) {
   return Bucket_Boruvka::get_index_hash(update_idx, checksum_seed());
 }
@@ -96,6 +97,8 @@ std::vector<size_t> const Sketch::get_bucket_ids(const vec_t update_idx) {
     size_t bucket_id = i * bkt_per_col + depth;
     likely_if(depth < bkt_per_col) {
       bucket_ids.push_back(bucket_id);
+    } else {
+      bucket_ids.push_back(-1);
     }
   }
   return bucket_ids;
@@ -109,9 +112,12 @@ void Sketch::update_buckets(const vec_t update_idx, const vec_hash_t checksum, c
   // Update higher depth buckets
   for (unsigned i = 0; i < num_columns; ++i) {
     size_t bucket_id = bucket_ids[i];
-    Bucket_Boruvka::update(buckets[bucket_id], update_idx, checksum);
+    likely_if (bucket_id < (size_t)(-1)) {
+      Bucket_Boruvka::update(buckets[bucket_id], update_idx, checksum);
+    }
   }
 }
+#endif
 
 void Sketch::zero_contents() {
   for (size_t i = 0; i < num_buckets; i++) {

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -447,3 +447,23 @@ TEST(SketchTestSuite, TestRawBucketUpdate) {
   }
   ASSERT_GT(successes, 0);
 }
+
+TEST(SketchTestSuite, TestDecomposedUpdate) {
+  size_t runs = 10;
+  size_t vec_size = 2000;
+  for (size_t i = 0; i < runs; i++) {
+    long seed = rand();
+
+    Sketch sketch_1(vec_size, seed, 1, log2(vec_size));
+    Sketch sketch_2(vec_size, seed, 1, log2(vec_size));
+
+    sketch_1.update(1);
+    
+    vec_hash_t checksum = sketch_2.get_checksum(1);
+    std::vector<vec_t> bucket_ids = sketch_2.get_bucket_ids(1);
+    sketch_2.update_buckets(1, checksum, bucket_ids);
+
+    ASSERT_EQ(sketch_1, sketch_2) << "Sketches not the same";
+
+  }
+}

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -448,12 +448,14 @@ TEST(SketchTestSuite, TestRawBucketUpdate) {
   ASSERT_GT(successes, 0);
 }
 
+#ifndef L0_SAMPLING
 TEST(SketchTestSuite, TestDecomposedUpdate) {
-  size_t runs = 10;
+  size_t runs = 1000;
   size_t vec_size = 2000;
   for (size_t i = 0; i < runs; i++) {
     long seed = rand();
-
+    
+    std::cout << "seed: " << seed << std::endl;
     Sketch sketch_1(vec_size, seed, 1, log2(vec_size));
     Sketch sketch_2(vec_size, seed, 1, log2(vec_size));
 
@@ -467,3 +469,4 @@ TEST(SketchTestSuite, TestDecomposedUpdate) {
 
   }
 }
+#endif

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -448,25 +448,23 @@ TEST(SketchTestSuite, TestRawBucketUpdate) {
   ASSERT_GT(successes, 0);
 }
 
-#ifndef L0_SAMPLING
 TEST(SketchTestSuite, TestDecomposedUpdate) {
   size_t runs = 1000;
   size_t vec_size = 2000;
   for (size_t i = 0; i < runs; i++) {
     long seed = rand();
-    
+
     std::cout << "seed: " << seed << std::endl;
     Sketch sketch_1(vec_size, seed, 1, log2(vec_size));
     Sketch sketch_2(vec_size, seed, 1, log2(vec_size));
 
     sketch_1.update(1);
     
-    vec_hash_t checksum = sketch_2.get_checksum(1);
-    std::vector<vec_t> bucket_ids = sketch_2.get_bucket_ids(1);
-    sketch_2.update_buckets(1, checksum, bucket_ids);
+    SketchDelta delta = sketch_2.get_delta(1);
+
+    sketch_2.apply_delta(delta);
 
     ASSERT_EQ(sketch_1, sketch_2) << "Sketches not the same";
 
   }
 }
-#endif


### PR DESCRIPTION
Added 3 different functions that perform different parts of a sketch update to avoid recalculating hashes when performing sketch updates, in cases where you want to apply the same update to sketches with the same randomness,

