### PR TITLE
Failed sketch merge should leave sketch in bad state

### DIFF
--- a/include/cc_sketch_alg.h
+++ b/include/cc_sketch_alg.h
@@ -241,4 +241,5 @@ class CCSketchAlg {
   // getters
   inline node_id_t get_num_vertices() { return num_vertices; }
   inline size_t get_seed() { return seed; }
+  inline size_t max_rounds() { return sketches[0]->get_num_samples(); }
 };

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -164,6 +164,7 @@ class Sketch {
   inline size_t checksum_seed() const { return seed; }
   inline size_t get_columns() const { return num_columns; }
   inline size_t get_buckets() const { return num_buckets; }
+  inline size_t get_num_samples() const { return num_samples; }
 
   static size_t calc_bkt_per_col(size_t n) { return ceil(log2(n)) + 1; }
   static size_t calc_cc_samples(size_t n) { return ceil(log2(n) / num_samples_div); }

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -156,6 +156,7 @@ void Sketch::merge(const Sketch &other) {
 void Sketch::range_merge(const Sketch &other, size_t start_sample, size_t n_samples) {
   if (start_sample + n_samples > num_samples) {
     assert(false);
+    sample_idx = num_samples; // sketch is in a fail state!
     return;
   }
 


### PR DESCRIPTION
Quick bug fix. Failing due to OutOfSamplesException wasn't working correctly because a failed merge became a no-op and didn't leave the sketch in a fail state. Now sketch produced from failed merge will always throw an exception when queried.