### PR TITLE
Make sketches_factor actually do something and fix exception race-case

### DIFF
--- a/include/cc_alg_configuration.h
+++ b/include/cc_alg_configuration.h
@@ -26,7 +26,7 @@ public:
 
   // getters
   std::string get_disk_dir() { return _disk_dir; }
-  double get_sketch_factor() { return _sketches_factor; }
+  double get_sketches_factor() { return _sketches_factor; }
   double get_batch_factor() { return _batch_factor; }
 
   friend std::ostream& operator<< (std::ostream &out, const CCAlgConfiguration &conf);

--- a/include/cc_sketch_alg.h
+++ b/include/cc_sketch_alg.h
@@ -45,9 +45,9 @@ struct alignas(64) GlobalMergeData {
   size_t num_merge_needed = -1;
   size_t num_merge_done = 0;
 
-  GlobalMergeData(node_id_t num_vertices, size_t seed)
+  GlobalMergeData(node_id_t num_vertices, size_t seed, double sketches_factor)
       : sketch(Sketch::calc_vector_length(num_vertices), seed,
-               Sketch::calc_cc_samples(num_vertices)) {}
+               Sketch::calc_cc_samples(num_vertices, sketches_factor)) {}
 
   GlobalMergeData(const GlobalMergeData&& other)
   : sketch(other.sketch) {
@@ -155,8 +155,9 @@ class CCSketchAlg {
     num_delta_sketches = num_workers;
     delta_sketches = new Sketch *[num_delta_sketches];
     for (size_t i = 0; i < num_delta_sketches; i++) {
-      delta_sketches[i] = new Sketch(Sketch::calc_vector_length(num_vertices), seed,
-                                     Sketch::calc_cc_samples(num_vertices));
+      delta_sketches[i] =
+          new Sketch(Sketch::calc_vector_length(num_vertices), seed,
+                     Sketch::calc_cc_samples(num_vertices, config.get_sketches_factor()));
     }
   }
 

--- a/include/dsu.h
+++ b/include/dsu.h
@@ -70,11 +70,11 @@ class DisjointSetUnion {
 
   inline T find_root(T u) {
     assert(0 <= u && u < n);
-    while (parent[parent[u]] != u) {
+    while (parent[parent[u]] != parent[u]) {
       parent[u] = parent[parent[u]];
       u = parent[u];
     }
-    return u;
+    return parent[u];
   }
 
   inline DSUMergeRet<T> merge(T u, T v) {
@@ -144,11 +144,11 @@ class DisjointSetUnion_MT {
 
   inline T find_root(T u) {
     assert(0 <= u && u < n);
-    while (parent[parent[u]] != u) {
+    while (parent[parent[u]] != parent[u]) {
       parent[u] = parent[parent[u]].load();
       u = parent[u];
     }
-    return u;
+    return parent[u];
   }
 
   // use CAS in this function to allow for simultaneous merge calls

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -172,10 +172,10 @@ class Sketch {
 #ifdef L0_SAMPLING
   static constexpr size_t default_cols_per_sample = 7;
   // NOTE: can improve this but leaving for comparison purposes
-  static constexpr double num_samples_div = log2(3) - 1;
+  static constexpr double num_samples_div = 0.5849625007211561; // log2(3) - 1
 #else
   static constexpr size_t default_cols_per_sample = 1;
-  static constexpr double num_samples_div = 1 - log2(2 - 0.8);
+  static constexpr double num_samples_div = 0.7369655941662062; // 1 - log2(2 - 0.8)
 #endif
 };
 

--- a/include/sketch.h
+++ b/include/sketch.h
@@ -64,6 +64,18 @@ class Sketch {
   }
 
   /**
+   * This function computes the number of samples a Sketch should support in order to solve
+   * connected components. Optionally, can increase or decrease the number of samples by a
+   * multiplicative factor.
+   * @param num_vertices   Number of graph vertices
+   * @param f              Multiplicative sample factor
+   * @return               The number of samples
+   */
+  static size_t calc_cc_samples(node_id_t num_vertices, double f) {
+    return ceil(f * log2(num_vertices) / num_samples_div);
+  }
+
+  /**
    * Construct a sketch object
    * @param vector_len       Length of the vector we are sketching
    * @param seed             Random seed of the sketch
@@ -167,15 +179,14 @@ class Sketch {
   inline size_t get_num_samples() const { return num_samples; }
 
   static size_t calc_bkt_per_col(size_t n) { return ceil(log2(n)) + 1; }
-  static size_t calc_cc_samples(size_t n) { return ceil(log2(n) / num_samples_div); }
 
 #ifdef L0_SAMPLING
   static constexpr size_t default_cols_per_sample = 7;
   // NOTE: can improve this but leaving for comparison purposes
-  static constexpr double num_samples_div = 0.5849625007211561; // log2(3) - 1
+  static constexpr double num_samples_div = log2(3) - 1;
 #else
   static constexpr size_t default_cols_per_sample = 1;
-  static constexpr double num_samples_div = 0.7369655941662062; // 1 - log2(2 - 0.8)
+  static constexpr double num_samples_div = 1 - log2(2 - 0.8);
 #endif
 };
 

--- a/src/cc_alg_configuration.cpp
+++ b/src/cc_alg_configuration.cpp
@@ -14,11 +14,6 @@ CCAlgConfiguration& CCAlgConfiguration::sketches_factor(double factor) {
               << "Defaulting to 1." << std::endl;
     _sketches_factor = 1;
   }
-  if (_sketches_factor != 1) {
-    std::cerr << "WARNING: Your graph configuration specifies using a factor " << _sketches_factor 
-              << " of the normal quantity of sketches." << std::endl;
-    std::cerr << "         Is this intentional? If not, set sketches_factor to one!" << std::endl;
-  }
   return *this;
 }
 

--- a/src/cc_sketch_alg.cpp
+++ b/src/cc_sketch_alg.cpp
@@ -90,12 +90,14 @@ void CCSketchAlg::pre_insert(GraphUpdate upd, int /* thr_id */) {
     auto src = std::min(edge.src, edge.dst);
     auto dst = std::max(edge.src, edge.dst);
     std::lock_guard<std::mutex> sflock(spanning_forest_mtx[src]);
-    if (spanning_forest[src].find(dst) != spanning_forest[src].end()) {
+    if (dsu.merge(src, dst).merged) {
+      // this edge adds new connectivity information so add to spanning forest
+      spanning_forest[src].insert(dst);
+    }
+    else if (spanning_forest[src].find(dst) != spanning_forest[src].end()) {
+      // this update deletes one of our spanning forest edges so mark dsu invalid
       dsu_valid = false;
       shared_dsu_valid = false;
-    } else {
-      spanning_forest[src].insert(dst);
-      dsu.merge(src, dst);
     }
   }
 #endif  // NO_EAGER_DSU

--- a/src/cc_sketch_alg.cpp
+++ b/src/cc_sketch_alg.cpp
@@ -14,10 +14,7 @@ CCSketchAlg::CCSketchAlg(node_id_t num_vertices, size_t seed, CCAlgConfiguration
   sketches = new Sketch *[num_vertices];
 
   vec_t sketch_vec_len = Sketch::calc_vector_length(num_vertices);
-  size_t sketch_num_samples = Sketch::calc_cc_samples(num_vertices) * config.get_sketch_factor();
-
-  std::cout << "sketch vector length = " << sketch_vec_len << std::endl;
-  std::cout << "sketch samples = " << sketch_num_samples << std::endl;
+  size_t sketch_num_samples = Sketch::calc_cc_samples(num_vertices, config.get_sketches_factor());
 
   for (node_id_t i = 0; i < num_vertices; ++i) {
     representatives->insert(i);
@@ -52,7 +49,8 @@ CCSketchAlg::CCSketchAlg(node_id_t num_vertices, size_t seed, std::ifstream &bin
   sketches = new Sketch *[num_vertices];
 
   vec_t sketch_vec_len = Sketch::calc_vector_length(num_vertices);
-  size_t sketch_num_samples = Sketch::calc_cc_samples(num_vertices) * config.get_sketch_factor();
+  size_t sketch_num_samples = Sketch::calc_cc_samples(num_vertices, config.get_sketches_factor());
+
   for (node_id_t i = 0; i < num_vertices; ++i) {
     representatives->insert(i);
     sketches[i] = new Sketch(sketch_vec_len, seed, binary_stream, sketch_num_samples);
@@ -263,7 +261,7 @@ bool CCSketchAlg::perform_boruvka_round(const size_t cur_round,
   {
     // some thread local variables
     Sketch local_sketch(Sketch::calc_vector_length(num_vertices), seed,
-                        Sketch::calc_cc_samples(num_vertices));
+                        Sketch::calc_cc_samples(num_vertices, config.get_sketches_factor()));
 
     size_t thr_id = omp_get_thread_num();
     size_t num_threads = omp_get_num_threads();
@@ -475,7 +473,7 @@ void CCSketchAlg::boruvka_emulation() {
   std::vector<GlobalMergeData> global_merges;
   global_merges.reserve(num_threads);
   for (size_t i = 0; i < num_threads; i++) {
-    global_merges.emplace_back(num_vertices, seed);
+    global_merges.emplace_back(num_vertices, seed, config.get_sketches_factor());
   }
 
   dsu.reset();

--- a/src/return_types.cpp
+++ b/src/return_types.cpp
@@ -32,6 +32,7 @@ std::vector<std::set<node_id_t>> ConnectedComponents::get_component_sets() {
 SpanningForest::SpanningForest(node_id_t num_vertices,
                                const std::unordered_set<node_id_t> *spanning_forest)
     : num_vertices(num_vertices) {
+  edges.reserve(num_vertices);
   for (node_id_t src = 0; src < num_vertices; src++) {
     for (node_id_t dst : spanning_forest[src]) {
       edges.push_back({src, dst});

--- a/test/sketch_test.cpp
+++ b/test/sketch_test.cpp
@@ -363,7 +363,7 @@ TEST(SketchTestSuite, TestExhaustiveQuery) {
 
 TEST(SketchTestSuite, TestSampleInsertGrinder) {
   size_t nodes = 4096;
-  Sketch sketch(Sketch::calc_vector_length(nodes), get_seed(), Sketch::calc_cc_samples(nodes));
+  Sketch sketch(Sketch::calc_vector_length(nodes), get_seed(), Sketch::calc_cc_samples(nodes, 1));
 
   for (size_t src = 0; src < nodes - 1; src++) {
     for (size_t dst = src + 7; dst < nodes; dst += 7) {
@@ -372,7 +372,7 @@ TEST(SketchTestSuite, TestSampleInsertGrinder) {
   }
 
   size_t successes = 0;
-  for (size_t i = 0; i < Sketch::calc_cc_samples(nodes); i++) {
+  for (size_t i = 0; i < Sketch::calc_cc_samples(nodes, 1); i++) {
     SketchSample ret = sketch.sample();
     if (ret.result == FAIL) continue;
 
@@ -388,7 +388,7 @@ TEST(SketchTestSuite, TestSampleInsertGrinder) {
 
 TEST(SketchTestSuite, TestSampleDeleteGrinder) {
   size_t nodes = 4096;
-  Sketch sketch(Sketch::calc_vector_length(nodes), get_seed(), Sketch::calc_cc_samples(nodes));
+  Sketch sketch(Sketch::calc_vector_length(nodes), get_seed(), Sketch::calc_cc_samples(nodes, 1));
 
   // insert
   for (size_t src = 0; src < nodes - 1; src++) {
@@ -405,7 +405,7 @@ TEST(SketchTestSuite, TestSampleDeleteGrinder) {
   }
 
   size_t successes = 0;
-  for (size_t i = 0; i < Sketch::calc_cc_samples(nodes); i++) {
+  for (size_t i = 0; i < Sketch::calc_cc_samples(nodes, 1); i++) {
     SketchSample ret = sketch.sample();
     if (ret.result == FAIL) continue;
 

--- a/test/util/mat_graph_verifier.cpp
+++ b/test/util/mat_graph_verifier.cpp
@@ -19,7 +19,7 @@ void MatGraphVerifier::edge_update(node_id_t src, node_id_t dst) {
   // update adj_matrix entry
   adj_matrix[src][dst] = !adj_matrix[src][dst];
 }
-  
+
 
 void MatGraphVerifier::reset_cc_state() {
   kruskal_ref = kruskal();

--- a/tools/process_stream.cpp
+++ b/tools/process_stream.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
   std::cout << std::endl;
 
   auto driver_config = DriverConfiguration().gutter_sys(CACHETREE).worker_threads(num_threads);
-  auto cc_config = CCAlgConfiguration().batch_factor(1);
+  auto cc_config = CCAlgConfiguration().batch_factor(1).sketches_factor(0.5);
   CCSketchAlg cc_alg{num_nodes, get_seed(), cc_config};
   GraphSketchDriver<CCSketchAlg> driver{&cc_alg, &stream, driver_config, reader_threads};
 

--- a/tools/process_stream.cpp
+++ b/tools/process_stream.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
   std::cout << std::endl;
 
   auto driver_config = DriverConfiguration().gutter_sys(CACHETREE).worker_threads(num_threads);
-  auto cc_config = CCAlgConfiguration().batch_factor(1).sketches_factor(0.5);
+  auto cc_config = CCAlgConfiguration().batch_factor(1);
   CCSketchAlg cc_alg{num_nodes, get_seed(), cc_config};
   GraphSketchDriver<CCSketchAlg> driver{&cc_alg, &stream, driver_config, reader_threads};
 

--- a/tools/test_correctness.cpp
+++ b/tools/test_correctness.cpp
@@ -22,7 +22,7 @@ CorrectnessResults test_path_correctness(size_t num_vertices, size_t num_graphs,
                                          size_t samples_per_graph) {
   CorrectnessResults results;
 
-  size_t num_rounds = Sketch::calc_cc_samples(num_vertices);
+  size_t num_rounds = Sketch::calc_cc_samples(num_vertices, 1);
   for (size_t r = 0; r < num_rounds; r++)
     results.num_round_hist.push_back(0);
 


### PR DESCRIPTION
Main branch has problems:
- Currently we have the sketches factor option in the configuration but it doesn't affect anything... oops.
- When our threads throw an exception this can cause a race case resulting in memory errors instead of exiting gracefully. 
- log2(const expr) is not always a const expr with all compilers.
- The pre_insert function builds a representation of the entire graph on an insert only stream. yikes. Instead we want to just maintain the spanning forest edges.

This pull request fixes all of those problems.